### PR TITLE
Adding deploy new pool button component

### DIFF
--- a/src/assets/svg/plus.svg
+++ b/src/assets/svg/plus.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 5V19" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 12H19" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svg/plus_gradient.svg
+++ b/src/assets/svg/plus_gradient.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 5V19" stroke="url(#paint0_linear_546_381)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 12H19" stroke="url(#paint0_linear_546_381)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<linearGradient id="paint0_linear_546_381" x1="2.70483" y1="12.4407" x2="21" y2="12.4407" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9BAAF3"/>
+<stop offset="1" stop-color="#7BD8C0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/components/common/AppBody.ts
+++ b/src/components/common/AppBody.ts
@@ -4,4 +4,5 @@ import tw from 'twin.macro';
 export default styled.div`
   ${tw`bg-grey-50 w-full h-full text-white flex flex-col min-h-screen py-16`}
   font-family: 'Inter';
+  background-color: rgba(7, 14, 18, 1);
 `;

--- a/src/components/common/Buttons.tsx
+++ b/src/components/common/Buttons.tsx
@@ -219,6 +219,96 @@ export const WarningButton = styled.button`
   }
 `;
 
+export const OutlinedGradientButton = styled.button.attrs(
+  (props: { rounded?: boolean }) => props
+)`
+  ${(props) => props.rounded ? 'border-radius: 100px;' : 'border-radius: 8px;'}
+  padding: 16px 24px;
+  overflow: hidden;
+  position: relative;
+  line-height: 24px;
+  font-weight: 700;
+  color: #FFFFFF;
+
+  & ~ img {
+    display: block;
+  }
+
+  & ~ img.gradient {
+    display: none;
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    ${(props) => props.rounded ? 'border-radius: 100px;' : 'border-radius: 8px;'}
+    padding: 2px;
+    background: linear-gradient(90deg, #9baaf3 0%, #7bd8c0 100%);
+    -webkit-mask: linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+  }
+
+  &:hover {
+    box-shadow: 0px 8px 16px -4px rgba(126, 213, 197, 0.08),
+    0px 8px 24px -4px rgba(154, 173, 241, 0.12);
+    background-color: rgba(13, 23, 30, 1);
+
+    background: linear-gradient(90deg, #9BAAF3 0%, #7BD8C0 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-fill-color: transparent;
+
+    & ~ img {
+      display: none;
+    }
+
+    & ~ img.gradient {
+      display: block;
+    }
+  }
+
+  &:focus {
+    box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.2);
+    outline: none;
+    background-color: rgba(13, 23, 30, 1);
+    &:before {
+      background: rgba(7, 14, 18, 1);
+    }
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    background: transparent;
+    -webkit-background-clip: none;
+    -webkit-text-fill-color: #FFFFFF;
+    background-clip: none;
+    text-fill-color: #FFFFFF;
+
+    & ~ img {
+      opacity: 0.4;
+      display: block;
+    }
+    & ~ img.gradient {
+      display: none;
+    }
+  }
+
+  &.trailing {
+    padding-right: 60px;
+  }
+`;
+
+const TrailingIcon = styled.img`
+  position: absolute;
+  right: 24px;
+  pointer-events: none;
+`;
+
 const ButtonWithIconWrapper = styled.div`
   ${tw`flex flex-row items-center justify-start`}
   position: relative;
@@ -227,12 +317,14 @@ const ButtonWithIconWrapper = styled.div`
 
 export type ButtonWithIconProps = {
   icon: string;
+  gradientIcon?: string;
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   className?: string;
   buttonClassName?: string;
   children?: React.ReactNode;
   name?: string;
   disabled?: boolean;
+  rounded?: boolean;
 };
 
 export function LinkButtonWithIcon(props: ButtonWithIconProps) {
@@ -307,6 +399,26 @@ export function SecondaryButtonWithIcon(props: ButtonWithIconProps) {
       >
         {props.children}
       </SecondaryButton>
+    </ButtonWithIconWrapper>
+  );
+}
+
+export function OutlinedGradientButtonWithTrailingIcon(props: ButtonWithIconProps) {
+  return (
+    <ButtonWithIconWrapper onClick={props.onClick || (() => {})}>
+      <OutlinedGradientButton rounded={props.rounded || false} className='trailing'>
+        {props.children}
+      </OutlinedGradientButton>
+      <TrailingIcon
+        src={props.icon}
+        alt=''
+        className={classNames('w-6 h-6 absolute', props.className || '')}
+      />
+      <TrailingIcon
+        src={props.gradientIcon || props.icon}
+        alt=''
+        className={classNames('w-6 h-6 absolute gradient', props.className || '')}
+      />
     </ButtonWithIconWrapper>
   );
 }

--- a/src/components/common/Buttons.tsx
+++ b/src/components/common/Buttons.tsx
@@ -276,8 +276,23 @@ export const OutlinedGradientButton = styled.button.attrs(
     box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.2);
     outline: none;
     background-color: rgba(13, 23, 30, 1);
+
+    background: linear-gradient(90deg, #9BAAF3 0%, #7BD8C0 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-fill-color: transparent;
+    
     &:before {
       background: rgba(7, 14, 18, 1);
+    }
+
+    & ~ img {
+      display: none;
+    }
+
+    & ~ img.gradient {
+      display: block;
     }
   }
 

--- a/src/pages/BlendPoolSelectPage.tsx
+++ b/src/pages/BlendPoolSelectPage.tsx
@@ -1,12 +1,14 @@
 import React, { useContext, useState } from 'react';
-import { TertiaryButton } from '../components/common/Buttons';
+import { OutlinedGradientButtonWithTrailingIcon } from '../components/common/Buttons';
 import { BlendPoolMarkers } from '../data/BlendPoolMarkers';
 import BlendPoolSelectTableRow from '../components/poolselect/BlendPoolSelectTableRow';
 import EllipsesIcon from '../assets/svg/more_ellipses.svg';
 import LeftArrow from '../assets/svg/left_arrow.svg';
 import RightArrow from '../assets/svg/right_arrow.svg';
-import { TextInput } from '../components/common/Input';
 import SearchIcon from '../assets/svg/search.svg';
+import PlusIcon from '../assets/svg/plus.svg';
+import PlusGradientIcon from '../assets/svg/plus_gradient.svg';
+import { TextInput } from '../components/common/Input';
 import AppPage from '../components/common/AppPage';
 import PageHeading from '../components/common/PageHeading';
 import { BlendTableContext } from '../data/context/BlendTableContext';
@@ -65,12 +67,15 @@ export default function BlendPoolSelectPage() {
           rel='noopener noreferrer'
           tabIndex={-1}
         >
-          <TertiaryButton
+          <OutlinedGradientButtonWithTrailingIcon icon={PlusIcon} gradientIcon={PlusGradientIcon} rounded={true}>
+            <span>Deploy&nbsp;New&nbsp;Pool</span>
+          </OutlinedGradientButtonWithTrailingIcon>
+          {/* <TertiaryButton
             name='Deploy New Pool'
             className='flex-none px-8 py-3'
           >
             Deploy&nbsp;New&nbsp;Pool
-          </TertiaryButton>
+          </TertiaryButton> */}
         </a>
       </div>
       <div className='text-left rounded-md border-2 border-grey-200'>


### PR DESCRIPTION
Adding deploy new pool button component based on the spec from Figma. While doing so, I began laying out the framework for the new button specs from Figma. Let me know what needs fixing if anything. Some things to note are that the text may seem bigger than in the Figma which is due to the different fonts being used currently. Additionally, I am not sure if the `focus` state from the spec is meant to describe the `focus-visible` state, which indicates when the focus comes from the keyboard (more info can be found here: [https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible)).

As per usual, you can find some images of the component below:

Default:
![deploynewpool](https://user-images.githubusercontent.com/17186604/166329433-a0032b97-9b87-4f8c-b4f8-f707d8cd1c78.PNG)

Hover:
![deploynewpoolhover](https://user-images.githubusercontent.com/17186604/166329437-363bcf4d-82ca-4c17-9806-27b408fe99fc.PNG)

Focus:
![deploynewpoolfocus](https://user-images.githubusercontent.com/17186604/166329435-565318b3-3fd7-4a33-818b-840112c5f10f.PNG)

Disabled:
![deploynewpooldisabled](https://user-images.githubusercontent.com/17186604/166329436-4c1d08cf-6ec7-4512-9585-7bb1cf1995a1.PNG)


