### PR TITLE
Fixing width of risk card

### DIFF
--- a/src/components/common/RiskCard.tsx
+++ b/src/components/common/RiskCard.tsx
@@ -94,7 +94,7 @@ export default function RiskCard() {
   return (
     <Wrapper>
       <RiskImage src={image} />
-      <div className='flex flex-col justify-between p-8'>
+      <div className='w-full flex flex-col justify-between p-8'>
         <div className='flex flex-col gap-y-2'>
           {title}
           {description}


### PR DESCRIPTION
I noticed a slight bug with the width of the content on the risk card if the screen is wide enough and the card doesn't have much text causing the button to not extend to the edge. This is a very simple, one-line fix.