### PR TITLE
Added tooltip-button component

### DIFF
--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import InfoIcon from '../../assets/svg/info.svg';
+import styled from 'styled-components';
+import tw from 'twin.macro';
+import useClickOutside from '../../data/hooks/UseClickOutside';
+import { Text } from './Typography';
+
+const ICON_SIZES = {
+  S: 16,
+  M: 20,
+  L: 24,
+}
+
+const ICON_GAPS = {
+  S: 8,
+  M: 10,
+  L: 10,
+}
+
+const InfoButton = styled.button.attrs(
+  (props: { icon: string, iconSize: 'S' | 'M' | 'L' }) => props
+)`
+  ${tw`flex justify-center items-center`}
+  gap: ${(props) => ICON_GAPS[props.iconSize]}px;
+  color: rgba(130, 160, 182, 1);
+  border-radius: 8px;
+  line-height: 30px;
+  font-size: 18px;
+  &:after {
+    content: '';
+    display: block;
+    width: ${(props) => ICON_SIZES[props.iconSize]}px;
+    height: ${(props) => ICON_SIZES[props.iconSize]}px;
+    background-image: url(${(props) => props.icon});
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+  }
+`;
+
+const TooltipContainer = styled.div.attrs(
+  (props: {
+    position:
+      | 'top-left'
+      | 'top-center'
+      | 'top-right'
+      | 'bottom-left'
+      | 'bottom-center'
+      | 'bottom-right';
+    filled?: boolean;
+  }) => props
+)`
+  ${tw`flex flex-col items-center justify-center absolute`}
+  ${(props) => {
+    if (props.position.startsWith('top')) {
+      return 'bottom: calc(100% + 8px);';
+    } else {
+      return 'top: calc(100% + 8px);';
+    }
+  }}
+  ${(props) => {
+    if (props.position.endsWith('left')) {
+      return 'left: 0px;';
+    } else if (props.position.endsWith('right')) {
+      return 'right: 0px;';
+    } else {
+      return 'left: calc(50% - 120px);';
+    }
+  }}
+  padding: 16px;
+  z-index: 30;
+  border-radius: 8px;
+  width: 240px;
+  background-color: ${(props) =>
+    props.filled ? 'rgba(26, 41, 52, 1);' : 'rgba(7, 14, 18, 1);'
+  };
+  border: ${(props) =>
+    props.filled ? 'none;' : '1px solid rgba(43, 64, 80, 1);'
+  };
+
+
+  &:before {
+    content: '';
+    display: block;
+    position: absolute;
+    ${(props) => {
+      if (props.position.startsWith('top')) {
+        return props.filled ? 'bottom: -8px;' : 'bottom: -9px;';
+      } else {
+        return props.filled ? 'top: -8px;' : 'top: -8.9px;';
+      }
+    }}
+    ${(props) => {
+      if (props.position.endsWith('left')) {
+        return 'left: 24px;';
+      } else if (props.position.endsWith('right')) {
+        return 'right: 24px;';
+      } else {
+        return 'left: calc(50% - 8px);';
+      }
+    }}
+    width: 16px;
+    height: 16px;
+    transform: rotate(-45deg);
+    border-radius: 0 4px 0 0;
+    background-color: ${(props) =>
+      props.filled ? 'rgba(26, 41, 52, 1);' : 'rgba(7, 14, 18, 1);'
+    };
+    border-left: ${(props) =>
+      props.filled ? 'none;' : '1px solid rgba(43, 64, 80, 1);'
+    };
+    border-bottom: ${(props) =>
+      props.filled ? 'none;' : '1px solid rgba(43, 64, 80, 1);'
+    };
+  }
+`;
+
+export type TooltipProps = {
+  content: string;
+  buttonText: string;
+  buttonSize: 'S' | 'M' | 'L';
+  position:
+    | 'top-left'
+    | 'top-center'
+    | 'top-right'
+    | 'bottom-left'
+    | 'bottom-center'
+    | 'bottom-right';
+  title?: string;
+  filled?: boolean;
+};
+
+export function FilledTooltip(props: TooltipProps) {
+  const { content, buttonText, buttonSize, position, title, filled } = props;
+  const [isOpen, setIsOpen] = React.useState(false);
+  const tooltipRef = React.useRef<HTMLDivElement>(null);
+  useClickOutside(tooltipRef, () => setIsOpen(false), isOpen);
+  return (
+    <div className='inline-block relative' ref={tooltipRef}>
+      {isOpen && (
+        <TooltipContainer position={position} filled={filled}>
+          {title && (
+            <Text size='M' weight='medium' className='w-full text-left mb-2 opacity-80'>
+              {title}
+            </Text>
+          )}
+          <Text size='XS' color='rgba(236, 247, 255, 1)' className='opacity-80'>
+            {content}
+          </Text>
+        </TooltipContainer>
+      )}
+      <InfoButton icon={InfoIcon} iconSize={buttonSize} onClick={() => setIsOpen(!isOpen)}>
+        <Text size={buttonSize} weight='medium' color='rgba(130, 160, 182, 1)'>
+          {buttonText}
+        </Text>
+      </InfoButton>
+    </div>
+  );
+}

--- a/src/components/pool/MaxSlippageInput.tsx
+++ b/src/components/pool/MaxSlippageInput.tsx
@@ -3,10 +3,9 @@ import React, { Fragment } from 'react';
 import styled from 'styled-components';
 import tw from 'twin.macro';
 import { SectionLabel } from './DepositTab';
-import InfoIcon from '../../assets/svg/info.svg';
 import { Text } from '../common/Typography';
+import { FilledTooltip } from '../common/Tooltip';
 
-const LABEL_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 const MESSAGE_TEXT_COLOR = 'rgba(204, 223, 237, 1)';
 
 const PREDEFINED_MAX_SLIPPAGE_OPTIONS = [
@@ -101,7 +100,8 @@ export default function MaxSlippageInput(props: MaxSlippageInputProps) {
   return (
     <div className='w-full flex flex-col gap-y-2 mt-6'>
       <SectionLabel className='flex gap-x-2 mb-1'>
-        <Text size='S' weight='medium' color={LABEL_TEXT_COLOR} className='inline'>Max Slippage</Text> <img src={InfoIcon} width={16} height={16} alt='info' />
+        <FilledTooltip content='Est nisl feugiat turpis amet, in sit bibendum tincidunt et. Vitae aliquam quam tempor, facilisi.' buttonText='Max Slippage' buttonSize='S' position='top-left' filled={true} />
+        {/* <Text size='S' weight='medium' color={LABEL_TEXT_COLOR} className='inline'>Max Slippage</Text> <img src={InfoIcon} width={16} height={16} alt='info' /> */}
       </SectionLabel>
       <Tab.Group>
         <Tab.List>

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -4,13 +4,13 @@ import styled from 'styled-components';
 import tw from 'twin.macro';
 import PortfolioCard from '../components/portfolio/PortfolioCard';
 import EmptyPortfolio from '../components/portfolio/EmptyPortfolio';
-import InfoIcon from '../assets/svg/info.svg';
 import ExternalPortfolioCard from '../components/portfolio/ExternalPortfolioCard';
 import EmptyExternalPortfolio from '../components/portfolio/EmptyExternalPortfolio';
 import { GetTokenData } from '../data/TokenData';
 import { FeeTier } from '../data/BlendPoolMarkers';
 import { GetSiloData } from '../data/SiloData';
 import { Text } from '../components/common/Typography';
+import { FilledTooltip } from '../components/common/Tooltip';
 
 const PORTFOLIO_TITLE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 
@@ -23,25 +23,6 @@ const PortfolioCards = styled.div`
   ${tw`flex flex-wrap justify-center items-center`}
   gap: 24px;
   margin-top: 24px;
-`;
-
-const InfoButton = styled.button.attrs((props: { icon: string }) => props)`
-  ${tw`flex justify-center items-center`}
-  gap: 10px;
-  color: rgba(130, 160, 182, 1);
-  border-radius: 8px;
-  line-height: 30px;
-  font-size: 18px;
-  &:after {
-    content: '';
-    display: block;
-    width: 24px;
-    height: 24px;
-    background-image: url(${(props) => props.icon});
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
-  }
 `;
 
 export default function PortfolioPage() {
@@ -115,7 +96,13 @@ export default function PortfolioPage() {
             <Text size='XL' weight='medium' color={PORTFOLIO_TITLE_TEXT_COLOR}>
               Your External Positions
             </Text>
-            <InfoButton icon={InfoIcon}>What is this?</InfoButton>
+            <FilledTooltip
+              content='Est nisl feugiat turpis amet, in sit bibendum tincidunt et. Vitae aliquam quam tempor, facilisi.'
+              buttonText='What is this?'
+              buttonSize='L'
+              position='top-right'
+              filled={true}
+            />
           </div>
           <PortfolioCards>
             <ExternalPortfolioCard


### PR DESCRIPTION
Added the tooltip-button component (or at least the majority of it). This includes the top-left, top-center, top-right, bottom-left, bottom-center, and bottom-right orientation/positions. I have yet to implement the rest. Additionally, I have implemented the two styles of tooltips, filled and outlined. Furthermore, there is also the option to add a title as well as change the sizing of the button that opens the tooltip. If we have plans to implement a tooltip without a button (I assumed it is only meant to be used with buttons from the way it was shown on the Figma), I can pretty easily add that capability as well. Below are some images of the component:

#### Filled:
![tooltip1](https://user-images.githubusercontent.com/17186604/173482979-286d297b-7eb8-4c2c-9f6b-2a4f8be51960.PNG)
#### Outlined:
![tooltip2](https://user-images.githubusercontent.com/17186604/173482990-65843b1a-7b87-42cd-b597-34e708f81149.PNG)

