### PR TITLE
Added custom dropdown for pagination

### DIFF
--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -36,7 +36,6 @@ const DropdownList = styled.div`
   ${tw`flex flex-col`}
   position: absolute;
   right: 0px;
-  top: calc(100% + 10px);
   z-index: 10;
   min-width: 100%;
   padding: 12px;
@@ -45,6 +44,14 @@ const DropdownList = styled.div`
   border-radius: 16px;
   border: 1px solid ${DROPDOWN_LIST_BORDER_COLOR};
   box-shadow: 0px 8px 32px 0px ${DROPDOWN_LIST_SHADOW_COLOR};
+
+  &:not(.inverted) {
+    top: calc(100% + 10px);
+  }
+
+  &.inverted {
+    bottom: calc(100% + 10px);
+  }
 `;
 
 const MultiDropdownList = styled(DropdownList)`
@@ -84,17 +91,68 @@ const CheckContainer = styled.div`
 export type DropdownOption = {
   label: string;
   value: string;
-  isDefault: boolean;
 };
 
 export type DropdownProps = {
   options: DropdownOption[];
   selectedOption: DropdownOption;
   onSelect: (option: DropdownOption) => void;
+  placeAbove?: boolean;
+};
+
+export function Dropdown(props: DropdownProps) {
+  const { options, selectedOption, onSelect, placeAbove } = props;
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = React.useRef<HTMLDivElement>(null);
+  useClickOutside(dropdownRef, () => setIsOpen(false), isOpen);
+
+  const toggleList = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const selectItem = (option: DropdownOption) => {
+    onSelect(option);
+    setIsOpen(false);
+  };
+
+  return (
+    <DropdownWrapper ref={dropdownRef}>
+      <DropdownHeader onClick={toggleList}>
+        {selectedOption.label}
+        <img
+          className='absolute right-6'
+          src={isOpen ? DropdownArrowUp : DropdownArrowDown}
+          alt=''
+        />
+      </DropdownHeader>
+      {isOpen && (
+        <DropdownList className={placeAbove ? 'inverted' : ''}>
+          {options.map((option) => (
+            <DropdownOptionContainer
+              key={option.value}
+              onClick={() => selectItem(option)}
+            >
+              {option.label}
+            </DropdownOptionContainer>
+          ))}
+        </DropdownList>
+      )}
+    </DropdownWrapper>
+  );
+}
+
+export type DropdownWithPlaceholderOption = DropdownOption & {
+  isDefault: boolean;
+}
+
+export type DropdownWithPlaceholderProps = {
+  options: DropdownWithPlaceholderOption[];
+  selectedOption: DropdownWithPlaceholderOption;
+  onSelect: (option: DropdownWithPlaceholderOption) => void;
   placeholder: string;
 };
 
-export function DropdownWithPlaceholder(props: DropdownProps) {
+export function DropdownWithPlaceholder(props: DropdownWithPlaceholderProps) {
   const { options, selectedOption, onSelect, placeholder } = props;
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = React.useRef<HTMLDivElement>(null);
@@ -104,7 +162,7 @@ export function DropdownWithPlaceholder(props: DropdownProps) {
     setIsOpen(!isOpen);
   };
 
-  const selectItem = (option: DropdownOption, index: number) => {
+  const selectItem = (option: DropdownWithPlaceholderOption, index: number) => {
     onSelect(option);
     setIsOpen(false);
   };

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -5,6 +5,7 @@ import DropdownArrowDown from '../../assets/svg/dropdown_arrow_down.svg';
 import DropdownArrowUp from '../../assets/svg/dropdown_arrow_up.svg';
 import { CheckIcon } from '@heroicons/react/solid';
 import useClickOutside from '../../data/hooks/UseClickOutside';
+import { Text } from './Typography';
 
 const DROPDOWN_HEADER_BORDER_COLOR = 'rgba(34, 54, 69, 1)';
 const DROPDOWN_LIST_BG_COLOR = 'rgba(7, 14, 18, 1)';
@@ -15,7 +16,6 @@ const DROPDOWN_OPTION_BG_COLOR_ACTIVE = 'rgba(255, 255, 255, 0.1)';
 const CHECKBOX_BG_COLOR = 'rgba(255, 255, 255, 0.1)';
 const CHECKBOX_BG_COLOR_ACTIVE = 'rgba(82, 182, 154, 1)';
 
-
 const DropdownWrapper = styled.div`
   ${tw`flex flex-col items-start justify-evenly`}
   position: relative;
@@ -23,23 +23,26 @@ const DropdownWrapper = styled.div`
   overflow: visible;
 `;
 
-const DropdownHeader = styled.button`
+const DropdownHeader = styled.button.attrs(
+  (props: { small?: boolean }) => props
+)`
   ${tw`flex flex-row items-center justify-between`}
   background: transparent;
-  padding: 16px 52px 16px 24px;
+  padding: ${(props) =>
+    props.small ? '12px 36px 12px 16px' : '16px 52px 16px 24px'};
   border: 1px solid ${DROPDOWN_HEADER_BORDER_COLOR};
   border-radius: 100px;
   white-space: nowrap;
 `;
 
-const DropdownList = styled.div`
+const DropdownList = styled.div.attrs((props: { small?: boolean }) => props)`
   ${tw`flex flex-col`}
   position: absolute;
   right: 0px;
   z-index: 10;
   min-width: 100%;
-  padding: 12px;
-  gap: 8px;
+  padding: ${(props) => (props.small ? '8px' : '12px')};
+  gap: ${(props) => (props.small ? '4px' : '8px')};
   background-color: ${DROPDOWN_LIST_BG_COLOR};
   border-radius: 16px;
   border: 1px solid ${DROPDOWN_LIST_BORDER_COLOR};
@@ -98,10 +101,11 @@ export type DropdownProps = {
   selectedOption: DropdownOption;
   onSelect: (option: DropdownOption) => void;
   placeAbove?: boolean;
+  small?: boolean;
 };
 
 export function Dropdown(props: DropdownProps) {
-  const { options, selectedOption, onSelect, placeAbove } = props;
+  const { options, selectedOption, onSelect, placeAbove, small } = props;
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = React.useRef<HTMLDivElement>(null);
   useClickOutside(dropdownRef, () => setIsOpen(false), isOpen);
@@ -117,22 +121,22 @@ export function Dropdown(props: DropdownProps) {
 
   return (
     <DropdownWrapper ref={dropdownRef}>
-      <DropdownHeader onClick={toggleList}>
-        {selectedOption.label}
+      <DropdownHeader onClick={toggleList} small={small}>
+        <Text size={small ? 'XS' : 'M'}>{selectedOption.label}</Text>
         <img
-          className='absolute right-6'
+          className={small ? 'w-4 absolute right-3' : 'w-5 absolute right-6'}
           src={isOpen ? DropdownArrowUp : DropdownArrowDown}
           alt=''
         />
       </DropdownHeader>
       {isOpen && (
-        <DropdownList className={placeAbove ? 'inverted' : ''}>
+        <DropdownList className={placeAbove ? 'inverted' : ''} small={small}>
           {options.map((option) => (
             <DropdownOptionContainer
               key={option.value}
               onClick={() => selectItem(option)}
             >
-              {option.label}
+              <Text size={small ? 'XS' : 'M'}>{option.label}</Text>
             </DropdownOptionContainer>
           ))}
         </DropdownList>
@@ -143,7 +147,7 @@ export function Dropdown(props: DropdownProps) {
 
 export type DropdownWithPlaceholderOption = DropdownOption & {
   isDefault: boolean;
-}
+};
 
 export type DropdownWithPlaceholderProps = {
   options: DropdownWithPlaceholderOption[];
@@ -170,7 +174,9 @@ export function DropdownWithPlaceholder(props: DropdownWithPlaceholderProps) {
   return (
     <DropdownWrapper ref={dropdownRef}>
       <DropdownHeader onClick={toggleList}>
-        {selectedOption.isDefault ? placeholder : selectedOption.label}
+        <Text size='M'>
+          {selectedOption.isDefault ? placeholder : selectedOption.label}
+        </Text>
         <img
           className='absolute right-6'
           src={isOpen ? DropdownArrowUp : DropdownArrowDown}
@@ -185,7 +191,7 @@ export function DropdownWithPlaceholder(props: DropdownWithPlaceholderProps) {
               key={index}
               onClick={() => selectItem(option, index)}
             >
-              {option.label}
+              <Text size='M'>{option.label}</Text>
             </DropdownOptionContainer>
           ))}
         </DropdownList>
@@ -250,7 +256,7 @@ export function MultiDropdown(props: MultiDropdownProps) {
   return (
     <DropdownWrapper ref={dropdownRef}>
       <DropdownHeader onClick={toggleList}>
-        {dropdownLabel}
+        <Text size='M'>{dropdownLabel}</Text>
         <img
           className='absolute right-6'
           src={isOpen ? DropdownArrowUp : DropdownArrowDown}
@@ -285,7 +291,9 @@ export function MultiDropdown(props: MultiDropdownProps) {
                     alt=''
                   />
                 )}
-                <div className='flex-grow h-6'>{label}</div>
+                <div className='flex-grow h-6'>
+                  <Text size='M'>{label}</Text>
+                </div>
                 <CheckContainer className={isActive ? 'active' : ''}>
                   {isActive && (
                     <CheckIcon

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -133,6 +133,7 @@ export function Dropdown(props: DropdownProps) {
         <DropdownList className={placeAbove ? 'inverted' : ''} small={small}>
           {options.map((option) => (
             <DropdownOptionContainer
+              className={option.value === selectedOption.value ? 'active' : ''}
               key={option.value}
               onClick={() => selectItem(option)}
             >

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -3,26 +3,14 @@ import styled from 'styled-components';
 import { ELLIPSIS, usePagination } from '../../data/hooks/UsePagination';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/solid';
 import tw from 'twin.macro';
+import { Dropdown } from './Dropdown';
 
 const MAX_DISPLAYED_COUNT = 6;
-const ITEMS_PER_PAGE_OPTIONS = [10, 20, 50, 100];
 
 const Wrapper = styled.div`
   ${tw`w-full flex justify-between`}
   margin-top: 42px;
   margin-bottom: 34px;
-`;
-
-// Temporary until the dropdown component is merged
-const TemporaryDropdown = styled.select`
-  ${tw`flex justify-center items-center`}
-  width: 109px;
-  height: 42px;
-  background-color: transparent;
-  outline: 1px solid rgba(26, 41, 52, 1);
-  border-radius: 100px;
-  font-size: 12px;
-  padding: 12px 8px 12px 12px;
 `;
 
 const PaginationRangeText = styled.span`
@@ -82,12 +70,21 @@ const EllipsisWrapper = styled.span`
   height: 40px;
 `;
 
+export type ItemsPerPage = 10 | 20 | 50 | 100;
+
+const ItemsPerPageToOption = (itemsPerPage: ItemsPerPage) => {
+  return {
+    label: `${itemsPerPage.toString()} Results`,
+    value: itemsPerPage.toString(),
+  }
+}
+
 export type PaginationProps = {
   totalItems: number;
-  itemsPerPage: number;
+  itemsPerPage: ItemsPerPage;
   currentPage: number;
   onPageChange: (page: number) => void;
-  onItemsPerPageChange: (itemsPerPage: number) => void;
+  onItemsPerPageChange: (itemsPerPage: ItemsPerPage) => void;
 };
 
 export default function Pagination(props: PaginationProps) {
@@ -98,6 +95,12 @@ export default function Pagination(props: PaginationProps) {
     onPageChange,
     onItemsPerPageChange,
   } = props;
+  const itemsPerPageValues: ItemsPerPage[] = [10, 20, 50, 100];
+  const itemsPerPageOptions = itemsPerPageValues.map((value) => ({
+    label: `${value.toString()} Results`,
+    value: value.toString(),
+  }));
+  const itemsPerPageOption = ItemsPerPageToOption(itemsPerPage);
 
   const firstPage = 1;
   const lastPage = Math.ceil(totalItems / itemsPerPage);
@@ -130,18 +133,14 @@ export default function Pagination(props: PaginationProps) {
   return (
     <Wrapper>
       <div className='flex items-center gap-4'>
-        <TemporaryDropdown
-          defaultValue={itemsPerPage}
-          onChange={(e) =>
-            onItemsPerPageChange(parseInt(e.target.selectedOptions[0].value))
+        <Dropdown
+          options={itemsPerPageOptions}
+          selectedOption={itemsPerPageOption}
+          onSelect={(updatedOption) =>
+            onItemsPerPageChange(parseInt(updatedOption.value) as ItemsPerPage)
           }
-        >
-          {ITEMS_PER_PAGE_OPTIONS.map((itemsPerPageOption) => (
-            <option key={itemsPerPageOption} value={itemsPerPageOption}>
-              {itemsPerPageOption} Results
-            </option>
-          ))}
-        </TemporaryDropdown>
+          placeAbove={true}
+        />
         <PaginationRangeText>
           {startItem} - {endItem} of {totalItems}
         </PaginationRangeText>

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -140,6 +140,7 @@ export default function Pagination(props: PaginationProps) {
             onItemsPerPageChange(parseInt(updatedOption.value) as ItemsPerPage)
           }
           placeAbove={true}
+          small={true}
         />
         <PaginationRangeText>
           {startItem} - {endItem} of {totalItems}

--- a/src/pages/BlendPoolSelectPage.tsx
+++ b/src/pages/BlendPoolSelectPage.tsx
@@ -7,12 +7,13 @@ import { TertiaryButton } from '../components/common/Buttons';
 import {
   DropdownOption,
   DropdownWithPlaceholder,
+  DropdownWithPlaceholderOption,
   MultiDropdown,
   MultiDropdownOption
 } from '../components/common/Dropdown';
 import { FilterBadge } from '../components/common/FilterBadge';
 import { TextInput } from '../components/common/Input';
-import Pagination from '../components/common/Pagination';
+import Pagination, { ItemsPerPage } from '../components/common/Pagination';
 import { Display } from '../components/common/Typography';
 import WideAppPage from '../components/common/WideAppPage';
 import { ResolveBlendPoolDrawData } from '../data/BlendPoolDataResolver';
@@ -68,7 +69,7 @@ export default function BlendPoolSelectPage() {
     MultiDropdownOption[]
   >([]);
   const [page, setPage] = useState<number>(1);
-  const [itemsPerPage, setItemsPerPage] = useState<number>(10);
+  const [itemsPerPage, setItemsPerPage] = useState<10 | 20 | 50 | 100>(10);
   const sortByOptions = [
     {
       label: 'Default',
@@ -85,9 +86,9 @@ export default function BlendPoolSelectPage() {
       value: 'oldest',
       isDefault: false,
     },
-  ] as DropdownOption[];
+  ] as DropdownWithPlaceholderOption[];
   const [selectedSortByOption, setSelectedSortByOption] =
-    useState<DropdownOption>(sortByOptions[0]);
+    useState<DropdownWithPlaceholderOption>(sortByOptions[0]);
 
   const { poolDataMap } = useContext(BlendTableContext);
   const loadData = useCallback(async () => {
@@ -217,7 +218,7 @@ export default function BlendPoolSelectPage() {
     setPage(page);
   };
 
-  const handleItemsPerPageChange = (itemsPerPage: number) => {
+  const handleItemsPerPageChange = (itemsPerPage: ItemsPerPage) => {
     setItemsPerPage(itemsPerPage);
   };
 
@@ -262,7 +263,7 @@ export default function BlendPoolSelectPage() {
           <DropdownWithPlaceholder
             options={sortByOptions}
             selectedOption={selectedSortByOption}
-            onSelect={(option: DropdownOption) => {
+            onSelect={(option: DropdownWithPlaceholderOption) => {
               setSelectedSortByOption(option);
             }}
             placeholder='Sort By'


### PR DESCRIPTION
Building off of the existing dropdown component, I added a new dropdown for non-placeholder use cases. One thing I noticed is that this specific use case had a dropdown that was smaller in size than the original spec so I added an option to opt for this smaller size (width/height and font size). This PR transitions the pagination dropdown from the hardly usable default dropdown to the highly usable custom dropdown. As usual, I attached some images of the component below:

#### 10 Results (Closed)
![dropdown-closed1](https://user-images.githubusercontent.com/17186604/174449652-ec13d332-4c2c-4af1-b0bf-dccd241ab0b1.PNG)

#### 10 Results (Open)
![dropdown-open1](https://user-images.githubusercontent.com/17186604/174449649-9a4224f9-7f7a-467f-b55d-ca988dde7a3d.PNG)

#### 50 Results (Closed)
![dropdown-closed2](https://user-images.githubusercontent.com/17186604/174449653-5880ed81-a900-43b4-91f7-80540971f94b.PNG)

#### 50 Results (Open)
![dropdown-open2](https://user-images.githubusercontent.com/17186604/174449651-3b457151-4a5d-4a46-926d-fe0a3abb7457.PNG)

