### PR TITLE
Cleaning up UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense } from 'react';
-import { Route, Routes, Navigate } from 'react-router-dom';
+import React, { Suspense, useEffect } from 'react';
+import { Route, Routes, Navigate, useLocation } from 'react-router-dom';
 
 import WagmiProvider from './connector/WagmiProvider';
 import Header from './components/header/Header';
@@ -12,6 +12,7 @@ import GovernancePage from './pages/GovernancePage';
 import AppBody from './components/common/AppBody';
 import { RedirectPartialPath } from './util/RedirectPartialPath';
 import { BlendTableProvider } from './data/context/BlendTableContext';
+import ScrollToTop from './util/ScrollToTop';
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
       <Suspense fallback={null}>
         <WagmiProvider>
           <BlendTableProvider>
+            <ScrollToTop />
             <AppBody>
               <Header />
               <main className='flex-grow'>

--- a/src/components/common/AppBody.ts
+++ b/src/components/common/AppBody.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import tw from 'twin.macro';
 
 export default styled.div`
-  ${tw`bg-grey-50 w-full h-full text-white flex flex-col min-h-screen py-16`}
+  ${tw`w-full h-full text-white flex flex-col min-h-screen py-16`}
   font-family: 'Satoshi-Variable';
   font-weight: 500;
 `;

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -120,7 +120,7 @@ const TooltipContainer = styled.div.attrs(
 
 export type TooltipProps = {
   buttonSize: 'S' | 'M' | 'L';
-  content: string;
+  content: string | React.ReactNode;
   position:
     | 'top-left'
     | 'top-center'

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -18,7 +18,10 @@ const ICON_GAPS = {
 }
 
 const InfoButton = styled.button.attrs(
-  (props: { icon: string, iconSize: 'S' | 'M' | 'L' }) => props
+  (props: { 
+    icon: string,
+    iconSize: 'S' | 'M' | 'L',
+  }) => props
 )`
   ${tw`flex justify-center items-center`}
   gap: ${(props) => ICON_GAPS[props.iconSize]}px;
@@ -53,9 +56,9 @@ const TooltipContainer = styled.div.attrs(
   ${tw`flex flex-col items-center justify-center absolute`}
   ${(props) => {
     if (props.position.startsWith('top')) {
-      return 'bottom: calc(100% + 8px);';
+      return 'bottom: calc(100% + 14px);';
     } else {
-      return 'top: calc(100% + 8px);';
+      return 'top: calc(100% + 14px);';
     }
   }}
   ${(props) => {
@@ -116,9 +119,8 @@ const TooltipContainer = styled.div.attrs(
 `;
 
 export type TooltipProps = {
-  content: string;
-  buttonText: string;
   buttonSize: 'S' | 'M' | 'L';
+  content: string;
   position:
     | 'top-left'
     | 'top-center'
@@ -126,12 +128,14 @@ export type TooltipProps = {
     | 'bottom-left'
     | 'bottom-center'
     | 'bottom-right';
+  buttonClassName?: string;
+  buttonText?: string;
   title?: string;
   filled?: boolean;
 };
 
-export function FilledTooltip(props: TooltipProps) {
-  const { content, buttonText, buttonSize, position, title, filled } = props;
+export default function Tooltip(props: TooltipProps) {
+  const { buttonSize, content, position, buttonClassName, buttonText, title, filled } = props;
   const [isOpen, setIsOpen] = React.useState(false);
   const tooltipRef = React.useRef<HTMLDivElement>(null);
   useClickOutside(tooltipRef, () => setIsOpen(false), isOpen);
@@ -149,10 +153,12 @@ export function FilledTooltip(props: TooltipProps) {
           </Text>
         </TooltipContainer>
       )}
-      <InfoButton icon={InfoIcon} iconSize={buttonSize} onClick={() => setIsOpen(!isOpen)}>
-        <Text size={buttonSize} weight='medium' color='rgba(130, 160, 182, 1)'>
-          {buttonText}
-        </Text>
+      <InfoButton icon={InfoIcon} iconSize={buttonSize} onClick={() => setIsOpen(!isOpen)} className={buttonClassName}>
+        {buttonText && (
+          <Text size={buttonSize} weight='medium' color='rgba(130, 160, 182, 1)'>
+            {buttonText}
+          </Text>
+        )}
       </InfoButton>
     </div>
   );

--- a/src/components/common/WidgetHeading.tsx
+++ b/src/components/common/WidgetHeading.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Text } from './Typography';
 
 export type WidgetHeadingProps = {
   children?: React.ReactNode;
@@ -6,8 +7,8 @@ export type WidgetHeadingProps = {
 
 export default function WidgetHeading(props: WidgetHeadingProps) {
   return (
-    <h2 className='pb-2 text-xl text-left text-grey-1000 font-semibold'>
+    <Text size='L' weight='medium' color='rgba(255, 255, 255, 1)'>
       {props.children}
-    </h2>
+    </Text>
   );
 }

--- a/src/components/pool/MaxSlippageInput.tsx
+++ b/src/components/pool/MaxSlippageInput.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import tw from 'twin.macro';
 import { SectionLabel } from './DepositTab';
 import { Text } from '../common/Typography';
-import { FilledTooltip } from '../common/Tooltip';
+import Tooltip from '../common/Tooltip';
 
 const MESSAGE_TEXT_COLOR = 'rgba(204, 223, 237, 1)';
 
@@ -100,8 +100,7 @@ export default function MaxSlippageInput(props: MaxSlippageInputProps) {
   return (
     <div className='w-full flex flex-col gap-y-2 mt-6'>
       <SectionLabel className='flex gap-x-2 mb-1'>
-        <FilledTooltip content='Est nisl feugiat turpis amet, in sit bibendum tincidunt et. Vitae aliquam quam tempor, facilisi.' buttonText='Max Slippage' buttonSize='S' position='top-left' filled={true} />
-        {/* <Text size='S' weight='medium' color={LABEL_TEXT_COLOR} className='inline'>Max Slippage</Text> <img src={InfoIcon} width={16} height={16} alt='info' /> */}
+        <Tooltip content='Est nisl feugiat turpis amet, in sit bibendum tincidunt et. Vitae aliquam quam tempor, facilisi.' buttonText='Max Slippage' buttonSize='S' position='top-left' filled={true} />
       </SectionLabel>
       <Tab.Group>
         <Tab.List>

--- a/src/components/poolstats/PoolPieChartWidget.tsx
+++ b/src/components/poolstats/PoolPieChartWidget.tsx
@@ -85,7 +85,7 @@ const PieChartLabel = styled.div`
 
   // colors, borders, text
   border-radius: calc(var(--height) / 2);
-  background-color: rgb(17, 34, 46);
+  background-color: rgba(7, 14, 18, 1);
   color: rgba(255, 255, 255, 1);
   ${tw`font-bold`};
 `;

--- a/src/components/poolstats/PoolPieChartWidget.tsx
+++ b/src/components/poolstats/PoolPieChartWidget.tsx
@@ -318,7 +318,7 @@ export default function PoolPieChartWidget(props: PoolStatsWidgetProps) {
   const tooltipContent = <>As prices shift, tokens are moved between Uniswap{combinedSiloLabelA} to
   keep liquidity in range. Blend replicates Uniswap V2 payoffs with
   extreme capital efficiency, so most tokens can earn yield in{' '}
-  {combinedSiloLabelB}. Value marked as {<i>"Float"</i>} helps facilitate
+  {combinedSiloLabelB}. Value marked as {<em>"Float"</em>} helps facilitate
   gas-efficient withdrawals.</>;
 
   return (

--- a/src/components/poolstats/PoolPieChartWidget.tsx
+++ b/src/components/poolstats/PoolPieChartWidget.tsx
@@ -315,10 +315,16 @@ export default function PoolPieChartWidget(props: PoolStatsWidgetProps) {
   const firstHalfOfSlices = slices.slice(0, slices.length / 2).reverse();
   const secondHalfOfSlices = slices.slice(slices.length / 2);
 
+  const tooltipContent = <>As prices shift, tokens are moved between Uniswap{combinedSiloLabelA} to
+  keep liquidity in range. Blend replicates Uniswap V2 payoffs with
+  extreme capital efficiency, so most tokens can earn yield in{' '}
+  {combinedSiloLabelB}. Value marked as {<i>"Float"</i>} helps facilitate
+  gas-efficient withdrawals.</>;
+
   return (
     <div className='w-full flex flex-col items-start justify-start mb-8'>
       {/* TODO: Update styling of widget header to spec, add info icon, and ensure spacing around the component is to spec */}
-      <WidgetHeading>Token Allocation <Tooltip buttonSize='S' buttonClassName='ml-1 mr-1' content='Est nisl feugiat turpis amet, in sit bibendum tincidunt et. Vitae aliquam quam tempor, facilisi.' position='top-center' filled={true} /></WidgetHeading>
+      <WidgetHeading>Token Allocation <Tooltip buttonSize='S' buttonClassName='ml-1 mr-1' content={tooltipContent} position='top-center' filled={true} /></WidgetHeading>
       <div className='w-full h-full mt-4 flex flex-row flex-nowrap'>
         <div className='w-[227px] h-[227px] relative'>
           <PieChartContainer>
@@ -426,13 +432,6 @@ export default function PoolPieChartWidget(props: PoolStatsWidgetProps) {
             </div>
           </div>
         </TokenAllocationBreakdown>
-      </div>
-      <div className='text-grey-700 text-md mt-6 pb-2'>
-        As prices shift, tokens are moved between Uniswap{combinedSiloLabelA} to
-        keep liquidity in range. Blend replicates Uniswap V2 payoffs with
-        extreme capital efficiency, so most tokens can earn yield in{' '}
-        {combinedSiloLabelB}. Value marked as <i>"Float"</i> helps facilitate
-        gas-efficient withdrawals.
       </div>
     </div>
   );

--- a/src/components/poolstats/PoolPieChartWidget.tsx
+++ b/src/components/poolstats/PoolPieChartWidget.tsx
@@ -6,6 +6,7 @@ import { BlendPoolMarkers } from '../../data/BlendPoolMarkers';
 import { ResolveBlendPoolDrawData } from '../../data/BlendPoolDataResolver';
 
 import { BlendPoolContext } from '../../data/context/BlendPoolContext';
+import Tooltip from '../common/Tooltip';
 
 export type PoolStatsWidgetProps = {
   poolData: BlendPoolMarkers;
@@ -317,7 +318,7 @@ export default function PoolPieChartWidget(props: PoolStatsWidgetProps) {
   return (
     <div className='w-full flex flex-col items-start justify-start mb-8'>
       {/* TODO: Update styling of widget header to spec, add info icon, and ensure spacing around the component is to spec */}
-      <WidgetHeading>Token Allocation</WidgetHeading>
+      <WidgetHeading>Token Allocation <Tooltip buttonSize='S' buttonClassName='ml-1 mr-1' content='Est nisl feugiat turpis amet, in sit bibendum tincidunt et. Vitae aliquam quam tempor, facilisi.' position='top-center' filled={true} /></WidgetHeading>
       <div className='w-full h-full mt-4 flex flex-row flex-nowrap'>
         <div className='w-[227px] h-[227px] relative'>
           <PieChartContainer>

--- a/src/components/poolstats/PoolPositionWidget.tsx
+++ b/src/components/poolstats/PoolPositionWidget.tsx
@@ -6,6 +6,7 @@ import { RESPONSIVE_BREAKPOINT_MD } from '../../data/constants/Breakpoints';
 import { formatUSD } from '../../util/Numbers';
 import PercentChange from '../common/PercentChange';
 import { Display, Text } from '../common/Typography';
+import WidgetHeading from '../common/WidgetHeading';
 
 const PERFORMANCE_LABEL_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 const PERFORMANCE_VALUE_TEXT_COLOR = 'rgba(255, 255, 255, 1)';
@@ -45,7 +46,7 @@ export default function PoolPositionWidget(props: PoolPositionWidgetProps) {
   // TODO: Incorporate the pool data into the widget
   return (
     <Wrapper>
-      <Text size='L' weight='medium'>Your Position</Text>
+      <WidgetHeading>Your Position</WidgetHeading>
       <PerformanceCardGrid>
         <PerformanceCard>
           <Text size='M' weight='medium' color={PERFORMANCE_LABEL_TEXT_COLOR}>Total Value</Text>

--- a/src/components/poolstats/PoolStatsWidget.tsx
+++ b/src/components/poolstats/PoolStatsWidget.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../util/Numbers';
 import { useAccount, useBalance } from 'wagmi';
 import { Display, Text } from '../common/Typography';
+import WidgetHeading from '../common/WidgetHeading';
 
 const ROUNDING_PRECISION = 2;
 const POOL_STAT_LABEL_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
@@ -91,7 +92,7 @@ export default function PoolStatsWidget(props: PoolStatsWidgetProps) {
 
   return (
     <Wrapper>
-      <Text size='L' weight='medium'>Stats</Text>
+      <WidgetHeading>Stats</WidgetHeading>
       <PoolStatsWidgetGrid>
         <PoolStat>
           <Text size='S' weight='medium' color={POOL_STAT_LABEL_TEXT_COLOR}>APR</Text>

--- a/src/index.css
+++ b/src/index.css
@@ -59,5 +59,5 @@
 @tailwind utilities;
 
 html {
-  background-color: #11222e;
+  background-color: rgba(7, 14, 18, 1);
 }

--- a/src/pages/BlendPoolPage.tsx
+++ b/src/pages/BlendPoolPage.tsx
@@ -6,6 +6,7 @@ import { PreviousPageButton } from '../components/common/Buttons';
 import FeeTierContainer from '../components/common/FeeTierContainer';
 import RiskCard from '../components/common/RiskCard';
 import { Text } from '../components/common/Typography';
+import WidgetHeading from '../components/common/WidgetHeading';
 import PoolInteractionTabs from '../components/pool/PoolInteractionTabs';
 import TokenPairHeader from '../components/pool/TokenPairHeader';
 import PoolPieChartWidget from '../components/poolstats/PoolPieChartWidget';
@@ -100,7 +101,7 @@ export default function BlendPoolPage() {
           <PoolStatsWidget poolData={poolData} />
           <PoolPieChartWidget poolData={poolData} />
           <div className='flex flex-col gap-y-6 mt-16'>
-            <Text size='L' weight='medium'>About Aloe Blend Pool</Text>
+            <WidgetHeading>About Aloe Blend Pool</WidgetHeading>
             <Text size='M' weight='medium' color={ABOUT_MESSAGE_TEXT_COLOR} className='flex flex-col gap-y-6'>
               <p>
                 Placing funds into a Blend Vault will allow Aloe to use
@@ -119,7 +120,7 @@ export default function BlendPoolPage() {
             </Text>
           </div>
           <div className='flex flex-col gap-y-6 mt-16'>
-            <Text size='L' weight='medium'>Investing Risk</Text>
+            <WidgetHeading>Investing Risk</WidgetHeading>
             <RiskCard />
           </div>
         </div>

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -10,7 +10,7 @@ import { GetTokenData } from '../data/TokenData';
 import { FeeTier } from '../data/BlendPoolMarkers';
 import { GetSiloData } from '../data/SiloData';
 import { Text } from '../components/common/Typography';
-import { FilledTooltip } from '../components/common/Tooltip';
+import Tooltip from '../components/common/Tooltip';
 
 const PORTFOLIO_TITLE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 
@@ -96,7 +96,7 @@ export default function PortfolioPage() {
             <Text size='XL' weight='medium' color={PORTFOLIO_TITLE_TEXT_COLOR}>
               Your External Positions
             </Text>
-            <FilledTooltip
+            <Tooltip
               content='Est nisl feugiat turpis amet, in sit bibendum tincidunt et. Vitae aliquam quam tempor, facilisi.'
               buttonText='What is this?'
               buttonSize='L'

--- a/src/util/ScrollToTop.tsx
+++ b/src/util/ScrollToTop.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}


### PR DESCRIPTION
This PR includes:
- the correct background color for the pages
- automatically scroll to the top when navigating to a page (but not when clicking the back button)
- a missed tooltip for the pie chart widget
- a widget head heading component to ensure widget headers are consistent

I know that these all seem unrelated, which most of them are, but they are mostly small fixes or additions that help bring us closer to the spec. As usual, below I added some images of the updated/new components:
#### Background Color (Blend Select Page)
![background-color](https://user-images.githubusercontent.com/17186604/174494665-6a2c5306-7294-4c28-bd46-ba4af1ac8a17.PNG)
#### Background Color (Blend Pool Page)
![background-color2](https://user-images.githubusercontent.com/17186604/174494697-bbd1b8d8-bfa5-42a6-9369-7d652cc0c444.PNG)
#### Background Color (Portfolio Page)
![background-color3](https://user-images.githubusercontent.com/17186604/174494703-de9e2f92-db7e-4d72-b9eb-fe494ed43be6.PNG)
#### Token Allocation Tooltip (Closed)
![tokenallocation-tooltip-closed](https://user-images.githubusercontent.com/17186604/174494715-754ebac8-6fcd-4975-97a9-67e7d613bf4c.PNG)
#### Token Allocation Tooltip (Open)
![tokenallocation-tooltip-open](https://user-images.githubusercontent.com/17186604/174494726-bdee5be5-6211-46ea-946d-ef9ceeaf6e0f.PNG)


