### PR TITLE
Added etherscan link to pool page

### DIFF
--- a/src/pages/BlendPoolPage.tsx
+++ b/src/pages/BlendPoolPage.tsx
@@ -16,6 +16,7 @@ import { BlendPoolProvider } from '../data/context/BlendPoolContext';
 import { BlendTableContext } from '../data/context/BlendTableContext';
 import { GetSiloData } from '../data/SiloData';
 import { GetTokenData } from '../data/TokenData';
+import { ReactComponent as OpenIcon } from '../assets/svg/open.svg';
 
 const ABOUT_MESSAGE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 
@@ -89,6 +90,9 @@ export default function BlendPoolPage() {
             silo0={GetSiloData(poolData.silo0Address.toLowerCase())}
             silo1={GetSiloData(poolData.silo1Address.toLowerCase())}
           />
+          <a href={`https://etherscan.io/address/${poolData.poolAddress}`}>
+            <OpenIcon width={24} height={24} />
+          </a>
           <AbsoluteFeeTierContainer feeTier={poolData.feeTier} />
         </div>
         <GridExpandingDiv className='w-full min-w-[340px] md:mt-24 md:grid-flow-row-dense'>


### PR DESCRIPTION
As per Hayden's request, I added the etherscan link back to the pool page. Since this was not a part of the spec, I tried to make it fit with the design. Let me know if there you would like it adjusted or moved to another part of the page. As usual, below I attached some images of the updated page:
![etherscan-link](https://user-images.githubusercontent.com/17186604/174521490-b0453f18-a8d8-45ff-a55a-900be8528509.PNG)

