### PR TITLE
Cleaning up the browse card to fit the spec

### DIFF
--- a/src/components/browse/BrowseCard.tsx
+++ b/src/components/browse/BrowseCard.tsx
@@ -12,9 +12,10 @@ import {
 } from '../../data/constants/Breakpoints';
 import { GetSiloData } from '../../data/SiloData';
 import { GetTokenData } from '../../data/TokenData';
-import { getProminentColor } from '../../util/Colors';
+import { getBrighterColor, getProminentColor, rgb, rgba } from '../../util/Colors';
 import InvestedTypes from '../common/InvestedTypes';
 import TokenPairIcons from '../common/TokenPairIcons';
+import { Display, Text } from '../common/Typography';
 
 const CARD_BODY_BG_COLOR = 'rgba(13, 23, 30, 1)';
 const FEE_TIER_BG_COLOR = 'rgba(26, 41, 52, 1)';
@@ -121,29 +122,6 @@ const InfoCategoryContainer = styled.div`
   gap: 4px;
 `;
 
-const InfoCategory = styled.span`
-  ${tw`text-sm`}
-  color: ${INFO_CATEGORY_TEXT_COLOR};
-`;
-
-const rgb = (color: string) => {
-  return `rgb(${color})`;
-};
-
-const rgba = (color: string, alpha: number) => {
-  return `rgba(${color}, ${alpha})`;
-};
-
-// Very naive logic to get the brighter color used to pick which color to
-// use for the shadow
-const getBrighterColor = (color0: string, color1: string) => {
-  const values0 = color0.split(',').map((v) => parseInt(v.trim()));
-  const values1 = color1.split(',').map((v) => parseInt(v.trim()));
-  const avg0 = (values0[0] + values0[1] + values0[2]) / 3;
-  const avg1 = (values1[0] + values1[1] + values1[2]) / 3;
-  return avg0 > avg1 ? color0 : color1;
-};
-
 export type BrowseCardProps = {
   blendPoolMarkers: BlendPoolMarkers;
 };
@@ -171,10 +149,8 @@ export default function BrowseCard(props: BrowseCardProps) {
   const [token0Color, setToken0Color] = useState<string>('');
   const [token1Color, setToken1Color] = useState<string>('');
 
+  // TODO: Move this to a utility function
   useEffect(() => {
-    /**
-     * Add whatever async logic needed to calculate the gradients.
-     */
     let mounted = true;
     const calculateProminentColors = async () => {
       const token0Color = await getProminentColor(token0.iconPath || '');
@@ -206,9 +182,9 @@ export default function BrowseCard(props: BrowseCardProps) {
   return (
     <CardWrapper to={link} border={cardBorderGradient} shadow={cardShadowColor}>
       <CardTitleWrapper gradient={cardTitleBackgroundGradient}>
-        <span className='text-2xl font-bold'>
+        <Display size='M' weight='semibold'>
           {token0.ticker}-{token1.ticker}
-        </span>
+        </Display>
         <CardSubTitleWrapper>
           <TokenPairIcons
             token0IconPath={token0.iconPath}
@@ -216,12 +192,12 @@ export default function BrowseCard(props: BrowseCardProps) {
             token0AltText={`${token0.name}'s Icon`}
             token1AltText={`${token1.name}'s Icon`}
           />
-          <FeeTierContainer>Uniswap Fee Tier - {feeTier}</FeeTierContainer>
+          <FeeTierContainer><Text size='S' weight='medium'>Uniswap Fee Tier - {feeTier}</Text></FeeTierContainer>
         </CardSubTitleWrapper>
       </CardTitleWrapper>
       <CardBodyWrapper>
         <BodySubContainer>
-          <span>Invest your</span>
+          <Text size='M' weight='medium'>Invest your</Text>
           <InvestedTypes
             token0={token0}
             token1={token1}
@@ -234,18 +210,18 @@ export default function BrowseCard(props: BrowseCardProps) {
         <BodyDivider />
         <ResponsiveBodySubContainer>
           <InfoCategoryContainer>
-            <InfoCategory>Price per Share</InfoCategory>
-            <span className='text-2xl'>
+            <Text size='S' weight='medium' color={INFO_CATEGORY_TEXT_COLOR}>Price per Share</Text>
+            <Text size='XL' weight='medium'>
               ${pricePerShare.toLocaleString('en-US')} USD
-            </span>
+            </Text>
           </InfoCategoryContainer>
           <InfoCategoryContainer>
-            <InfoCategory>APR</InfoCategory>
-            <span className='text-2xl'>{aprFee}</span>
+            <Text size='S' weight='medium' color={INFO_CATEGORY_TEXT_COLOR}>APR</Text>
+            <Text size='XL' weight='medium'>{aprFee}</Text>
           </InfoCategoryContainer>
           <InfoCategoryContainer>
-            <InfoCategory>TVL</InfoCategory>
-            <span className='text-2xl'>{totalValueLocked}</span>
+            <Text size='S' weight='medium' color={INFO_CATEGORY_TEXT_COLOR}>TVL</Text>
+            <Text size='XL' weight='medium'>{totalValueLocked}</Text>
           </InfoCategoryContainer>
         </ResponsiveBodySubContainer>
       </CardBodyWrapper>


### PR DESCRIPTION
Updated the BrowseCard to fit the spec. This was done by updating the text to use the new(ish) Typography components. Additionally, I removed duplicate methods and replaced their usage with existing utility methods. As usual, below I attached an image of the updated component:
![browsecard-updated](https://user-images.githubusercontent.com/17186604/175467648-be668fd4-3a19-4f4a-826b-b67895e66db8.PNG)

