### PR TITLE
Fixing modal for wallet so it fits entire address

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -6,7 +6,8 @@ import styled from 'styled-components';
 import tw from 'twin.macro';
 import { Display } from './Typography';
 
-const DEFAULT_BORDER_GRADIENT = 'linear-gradient(90deg, #9BAAF3 0%, #7BD8C0 100%)';
+const DEFAULT_BORDER_GRADIENT =
+  'linear-gradient(90deg, #9BAAF3 0%, #7BD8C0 100%)';
 const LOADING_BORDER_GRADIENT = 'rgba(43, 64, 80, 1)';
 export const LABEL_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 export const VALUE_TEXT_COLOR = 'rgba(255, 255, 255, 1)';
@@ -17,11 +18,11 @@ const StyledDialog = styled.div`
 `;
 
 const ModalWrapper = styled.div.attrs(
-  (props: { borderGradient: string; }) => props
+  (props: { borderGradient: string }) => props
 )`
   ${tw`inline-block bg-grey-50 align-bottom rounded-lg text-left overflow-hidden transition-all sm:my-4 sm:align-middle`}
   transform: translateY(0);
-  width: 368px;
+  min-width: 368px;//TODO: make sure this doesn't break any modals
   max-width: 100%;
   background-color: rgba(13, 23, 30, 1);
   color: rgba(255, 255, 255, 1);
@@ -34,7 +35,7 @@ const ModalWrapper = styled.div.attrs(
     pointer-events: none;
     border-radius: 8px;
     padding: 1.25px;
-    background: ${props => props.borderGradient};
+    background: ${(props) => props.borderGradient};
     -webkit-mask: linear-gradient(#fff 0 0) content-box,
       linear-gradient(#fff 0 0);
     -webkit-mask-composite: xor;
@@ -136,7 +137,7 @@ function ModalBase(props: ModalBaseProps) {
             props.setOpen(false);
           }}
         >
-          <div className='flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0'>
+          <div className='flex items-center justify-center min-h-screen text-center'>
             <Transition.Child
               as={Fragment}
               enter='ease-out duration-300'
@@ -166,9 +167,7 @@ function ModalBase(props: ModalBaseProps) {
               leaveTo='opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
             >
               <ModalWrapper borderGradient={borderGradient}>
-                <div className='p-8'>
-                  {props.children}
-                </div>
+                <div className='p-8'>{props.children}</div>
               </ModalWrapper>
             </Transition.Child>
           </div>
@@ -187,9 +186,17 @@ export type CloseableModalProps = ModalProps & {
 export function CloseableModal(props: CloseableModalProps) {
   const cancelButtonRef = useRef(null);
   return (
-    <ModalBase open={props.open} setOpen={props.setOpen} onClose={props.onClose} initialFocusRef={cancelButtonRef} borderGradient={props.borderGradient}>
+    <ModalBase
+      open={props.open}
+      setOpen={props.setOpen}
+      onClose={props.onClose}
+      initialFocusRef={cancelButtonRef}
+      borderGradient={props.borderGradient}
+    >
       <div className='w-full flex flex-row items-center justify-between mb-8'>
-        <Display size='M' weight='semibold'>{props.title}</Display>
+        <Display size='M' weight='semibold'>
+          {props.title}
+        </Display>
         <button
           type='button'
           className='w-fit inline-flex justify-center rounded-full text-white focus:outline-none sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm'
@@ -215,14 +222,20 @@ type LoadingModalProps = ModalProps & {
 export function LoadingModal(props: LoadingModalProps) {
   const borderGradient = props.borderGradient || LOADING_BORDER_GRADIENT;
   return (
-    <ModalBase open={props.open} setOpen={(_open: boolean) => {}} borderGradient={borderGradient}>
+    <ModalBase
+      open={props.open}
+      setOpen={(_open: boolean) => {}}
+      borderGradient={borderGradient}
+    >
       <div className='w-full flex flex-row items-center justify-between mb-8'>
-        <Display size='M' weight='semibold'>{props.title}</Display>
+        <Display size='M' weight='semibold'>
+          {props.title}
+        </Display>
         <LoaderWrapper>
           <Loader src={LoadingIcon} alt='loader' />
         </LoaderWrapper>
       </div>
       {props.children}
     </ModalBase>
-  )
+  );
 }

--- a/src/components/header/ConnectWalletButton.tsx
+++ b/src/components/header/ConnectWalletButton.tsx
@@ -8,6 +8,7 @@ import {
   OutlinedGradientRoundedButton
 } from '../common/Buttons';
 import { mapConnectorNameToIcon } from './ConnectorIconMap';
+import { Text } from '../common/Typography';
 
 
 export default function ConnectWalletButton() {
@@ -39,19 +40,19 @@ export default function ConnectWalletButton() {
         <div className='w-full'>
           {accountData ? (
             // We have an account connected
-            <div className='flex flex-row items-center justify-between p-2 rounded-md border-2 border-grey-200 bg-grey-100'>
+            <div className='flex flex-col gap-y-2 items-center justify-between p-2 rounded-md border-2 border-grey-200 bg-grey-100'>
               {/*<img src={accountData.ens?.avatar || undefined} alt="ENS Avatar" />*/}
-              <div className='flex flex-col items-start justify-start'>
-                <div className='text-md'>
+              <div className='flex flex-col items-start justify-start w-full oveflow-hidden'>
+                <Text size='M' className='w-full overflow-hidden text-ellipsis' title={accountData.address}>
                   {accountData.ens?.name
                     ? `${accountData.ens?.name} (${FormatAddress(
                         accountData.address
                       )})`
-                    : FormatAddress(accountData.address)}
-                </div>
-                <div className='text-sm text-grey-800'>
+                    : accountData.address}
+                </Text>
+                <Text size='S' color='rgb(194, 209, 221)' className='w-full overflow-hidden text-ellipsis'>
                   Connected to {accountData.connector?.name}
-                </div>
+                </Text>
               </div>
               <FilledStylizedButton
                 name='Disconnect'
@@ -115,9 +116,9 @@ export default function ConnectWalletButton() {
             </div>
           )}
           {connectError && (
-            <div className='text-warning'>
+            <Text size='S' color='rgb(236, 45, 91)'>
               {connectError?.message ?? 'Failed to connect'}
-            </div>
+            </Text>
           )}
         </div>
       </CloseableModal>


### PR DESCRIPTION
Hayden mentioned how the connect wallet modal didn't show the entire address (as it was cut off), this PR aims to fix that. Below you find an image of the updated component:
![modal-fit-address](https://user-images.githubusercontent.com/17186604/176345491-19fe9b9b-0f68-4852-acd9-7ca6c6df98d7.PNG)

