### PR TITLE
Putting the final touches on the interaction tabs

### DIFF
--- a/src/components/header/ConnectWalletButton.tsx
+++ b/src/components/header/ConnectWalletButton.tsx
@@ -5,13 +5,16 @@ import { useAccount, useConnect } from 'wagmi';
 import { FormatAddress } from '../../util/FormatAddress';
 import {
   FilledStylizedButton,
-  OutlinedGradientRoundedButton
+  OutlinedGradientRoundedButton,
 } from '../common/Buttons';
 import { mapConnectorNameToIcon } from './ConnectorIconMap';
 import { Text } from '../common/Typography';
 
+export type ConnectWalletButtonProps = {
+  secondaryStyle?: boolean;
+};
 
-export default function ConnectWalletButton() {
+export default function ConnectWalletButton(props: ConnectWalletButtonProps) {
   const [modalOpen, setModalOpen] = useState<boolean>(false);
 
   const [{ data: connectData, error: connectError }, connect] = useConnect();
@@ -29,28 +32,54 @@ export default function ConnectWalletButton() {
 
   return (
     <div>
-      <OutlinedGradientRoundedButton
-        name={buttonText}
-        size='S'
-        onClick={() => setModalOpen(true)}
+      {!props.secondaryStyle && (
+        <OutlinedGradientRoundedButton
+          name={buttonText}
+          size='S'
+          onClick={() => setModalOpen(true)}
+        >
+          {buttonText}
+        </OutlinedGradientRoundedButton>
+      )}
+      {props.secondaryStyle && (
+        <FilledStylizedButton
+          name={buttonText}
+          size='M'
+          onClick={() => setModalOpen(true)}
+          backgroundColor='rgba(26, 41, 52, 1)'
+          color='rgba(255, 255, 255, 1)'
+          fillWidth={true}
+        >
+          {buttonText}
+        </FilledStylizedButton>
+      )}
+      <CloseableModal
+        open={modalOpen}
+        setOpen={setModalOpen}
+        title={'Connect Wallet'}
       >
-        {buttonText}
-      </OutlinedGradientRoundedButton>
-      <CloseableModal open={modalOpen} setOpen={setModalOpen} title={'Connect Wallet'}>
         <div className='w-full'>
           {accountData ? (
             // We have an account connected
             <div className='flex flex-col gap-y-2 items-center justify-between p-2 rounded-md border-2 border-grey-200 bg-grey-100'>
               {/*<img src={accountData.ens?.avatar || undefined} alt="ENS Avatar" />*/}
               <div className='flex flex-col items-start justify-start w-full oveflow-hidden'>
-                <Text size='M' className='w-full overflow-hidden text-ellipsis' title={accountData.address}>
+                <Text
+                  size='M'
+                  className='w-full overflow-hidden text-ellipsis'
+                  title={accountData.address}
+                >
                   {accountData.ens?.name
                     ? `${accountData.ens?.name} (${FormatAddress(
                         accountData.address
                       )})`
                     : accountData.address}
                 </Text>
-                <Text size='S' color='rgb(194, 209, 221)' className='w-full overflow-hidden text-ellipsis'>
+                <Text
+                  size='S'
+                  color='rgb(194, 209, 221)'
+                  className='w-full overflow-hidden text-ellipsis'
+                >
                   Connected to {accountData.connector?.name}
                 </Text>
               </div>
@@ -68,7 +97,7 @@ export default function ConnectWalletButton() {
           ) : (
             // No account connected, display connection options
             <div className='py-2'>
-              <div className='text-md'>
+              <Text size='M' weight='medium'>
                 By connecting a wallet, I agree to Aloe Labs, Inc's{' '}
                 <a
                   href={'/terms.pdf'}
@@ -88,7 +117,7 @@ export default function ConnectWalletButton() {
                   Privacy Policy
                 </a>
                 .
-              </div>
+              </Text>
               {connectData.connectors.map((connector) => (
                 <div
                   key={connector.id}

--- a/src/components/pool/ConnectWallet.tsx
+++ b/src/components/pool/ConnectWallet.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import DepositIllustration from '../../assets/svg/deposit_illustration.svg';
+import { Display, Text } from '../common/Typography';
 import ConnectWalletButton from '../header/ConnectWalletButton';
 
 const Wrapper = styled.div`
@@ -23,21 +24,6 @@ const Wrapper = styled.div`
   }
 `;
 
-const ConnectWalletHeader = styled.div`
-  /* font-family: 'ClashDisplay-Variable'; */
-  font-size: 24px;
-  font-weight: 600;
-  line-height: 32px;
-  color: rgba(255, 255, 255, 1);
-`;
-
-const ConnectWalletSubHeader = styled.div`
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 20px;
-  color: rgba(204, 223, 237, 1);
-`;
-
 export default function ConnectWallet() {
   return (
     <Wrapper>
@@ -45,13 +31,13 @@ export default function ConnectWallet() {
         <img src={DepositIllustration} alt='connect wallet illustrastion' />
       </div>
       <div className='flex flex-col gap-y-2 mb-8'>
-        <ConnectWalletHeader>Connect your wallet to start investing with Aloe</ConnectWalletHeader>
-        <ConnectWalletSubHeader>
+        <Display size='M' weight='semibold'>Connect your wallet to start investing with Aloe</Display>
+        <Text size='S' weight='medium' color='rgba(204, 223, 237, 1)'>
           By investing with Aloe, you will be able to lorem ipsum something
           something
-        </ConnectWalletSubHeader>
+        </Text>
       </div>
-      <ConnectWalletButton />
+      <ConnectWalletButton secondaryStyle={true} />
     </Wrapper>
   );
 }

--- a/src/components/pool/PoolInteractionTabs.tsx
+++ b/src/components/pool/PoolInteractionTabs.tsx
@@ -6,11 +6,14 @@ import WithdrawTab from './WithdrawTab';
 import tw from 'twin.macro';
 import styled from 'styled-components';
 import ConnectWallet from './ConnectWallet';
+import { useAccount } from 'wagmi';
 
 export const MODAL_BLACK_TEXT_COLOR = 'rgba(7, 14, 18, 1)';
 
 const Wrapper = styled.div`
-  ${tw`w-full rounded-md`}
+  ${tw`rounded-md`}
+  width: 100%;
+  max-width: 500px;
   background-color: rgba(13, 23, 30, 1);
 `;
 
@@ -98,7 +101,10 @@ export type PoolInteractionTabsProps = {
 };
 
 export default function PoolInteractionTabs(props: PoolInteractionTabsProps) {
-  const walletNotConnected = false;
+  const [{ data: accountData }] = useAccount({
+    fetchEns: true,
+  });
+  const walletNotConnected = !accountData || !accountData.address;
 
   return (
     <Wrapper>


### PR DESCRIPTION
Made it so that the interaction tabs detect if a wallet is connected and if one is not it shows the prompt to connect a wallet rather than the deposit/withdraw tabs. I also fixed the sizing so that the interaction tabs never get too wide. As per usual, below I attached some images of the updated components:
![connect-your-wallet-prompt](https://user-images.githubusercontent.com/17186604/176628555-6a373e3b-7dbc-43c7-81c9-7febce9e4cda.PNG)
![better-size](https://user-images.githubusercontent.com/17186604/176628567-399965d5-8804-4dd1-83b3-c3d2e1e778c5.PNG)

