### PR TITLE
Fixing placeholder sizing

### DIFF
--- a/src/components/browse/BrowseCardPlaceholder.tsx
+++ b/src/components/browse/BrowseCardPlaceholder.tsx
@@ -26,12 +26,12 @@ export const BrowseCardPlaceholder = styled.div`
   background-repeat: no-repeat;
   background-size: ${BROWSE_CARD_WIDTH_XL} ${BROWSE_CARD_PLACEHOLDER_HEIGHT_LG};
   display: inline-block;
-  animation: shimmer 1s forwards linear infinite;
+  animation: browseCardShimmer 1s forwards linear infinite;
   border-radius: 8px;
   overflow: hidden;
   position: relative;
 
-  @keyframes shimmer {
+  @keyframes browseCardShimmer {
     0% {
       background-position: -${BROWSE_CARD_WIDTH_XL} 0;
     }
@@ -42,9 +42,9 @@ export const BrowseCardPlaceholder = styled.div`
   @media (max-width: ${RESPONSIVE_BREAKPOINT_LG}) {
     width: ${BROWSE_CARD_WIDTH_LG};
     height: ${BROWSE_CARD_PLACEHOLDER_HEIGHT_LG};
-    background-size: ${BROWSE_CARD_WIDTH_LG} ${BROWSE_CARD_PLACEHOLDER_HEIGHT_LG};
+    background-size: ${BROWSE_CARD_WIDTH_LG} ${BROWSE_CARD_PLACEHOLDER_HEIGHT_MD};
 
-    @keyframes shimmer {
+    @keyframes browseCardShimmer {
       0% {
         background-position: -${BROWSE_CARD_WIDTH_LG} 0;
       }
@@ -56,10 +56,10 @@ export const BrowseCardPlaceholder = styled.div`
   @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
     width: ${BROWSE_CARD_WIDTH_MD};
     height: ${BROWSE_CARD_PLACEHOLDER_HEIGHT_MD};
-    background-size: ${BROWSE_CARD_WIDTH_MD} height: ${BROWSE_CARD_PLACEHOLDER_HEIGHT_MD};;
+    background-size: ${BROWSE_CARD_WIDTH_MD} height: ${BROWSE_CARD_PLACEHOLDER_HEIGHT_MD};
     margin: 0 auto;
 
-    @keyframes shimmer {
+    @keyframes browseCardShimmer {
       0% {
         background-position: -${BROWSE_CARD_WIDTH_MD} 0;
       }

--- a/src/components/graph/BlendGraphPlaceholder.tsx
+++ b/src/components/graph/BlendGraphPlaceholder.tsx
@@ -16,14 +16,14 @@ export const BlendGraphPlaceholder = styled.div`
   background-repeat: no-repeat;
   background-size: 900px 300px;
   display: inline-block;
-  animation: shimmer 1s forwards linear infinite;
+  animation: blendGraphShimmer 1s forwards linear infinite;
   overflow: hidden;
   position: relative;
   left: -32px;
   border-top-right-radius: 8px;
   border-bottom-right-radius: 8px;
 
-  @keyframes shimmer {
+  @keyframes blendGraphShimmer {
     0% {
       background-position: -900px 0;
     }


### PR DESCRIPTION
As the title suggests there was a small bug involving the sizing of the browse card placeholder on some screen sizes where the shimmer would only cover a portion of the card's height. This PR aims to fix that.