### PR TITLE
Rounding APR on browse card

### DIFF
--- a/src/components/browse/BrowseCard.tsx
+++ b/src/components/browse/BrowseCard.tsx
@@ -21,7 +21,7 @@ import InvestedTypes from '../common/InvestedTypes';
 import TokenPairIcons from '../common/TokenPairIcons';
 import { useContractRead } from 'wagmi';
 import AloeBlendABI from '../../assets/abis/AloeBlend.json';
-import { formatUSD, formatUSDCompact, String1E, toBig } from '../../util/Numbers';
+import { formatUSD, formatUSDCompact, roundPercentage, String1E, toBig } from '../../util/Numbers';
 import { BigNumber } from 'ethers';
 import { Display, Text } from '../common/Typography';
 
@@ -259,7 +259,7 @@ export default function BrowseCard(props: BrowseCardProps) {
           </InfoCategoryContainer>
           <InfoCategoryContainer>
             <Text size='S' weight='medium' color={INFO_CATEGORY_TEXT_COLOR}>APR</Text>
-            <Text size='XL' weight='medium'>{poolStats?.annual_percentage_rate}%</Text>
+            <Text size='XL' weight='medium'>{roundPercentage(poolStats?.annual_percentage_rate || 0)}%</Text>
           </InfoCategoryContainer>
           <InfoCategoryContainer>
             <Text size='S' weight='medium' color={INFO_CATEGORY_TEXT_COLOR}>TVL</Text>

--- a/src/util/Numbers.ts
+++ b/src/util/Numbers.ts
@@ -1,6 +1,8 @@
 import Big from 'big.js';
 import { ethers } from 'ethers';
 
+const DEFAULT_PRECISION = 2;
+
 const compactCurrencyFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
@@ -36,7 +38,8 @@ export function formatUSDCompact(amount: number): string {
  * @param precision the number of decimal places to round to
  * @returns the given percentage rounded to the given precision, without forcing a decimal point
  */
-export function roundPercentage(percentage: number, precision: number): number {
+export function roundPercentage(percentage: number, precision?: number): number {
+  precision = precision || DEFAULT_PRECISION;
   return (
     Math.round((percentage + Number.EPSILON) * Math.pow(10, precision)) /
     Math.pow(10, precision)


### PR DESCRIPTION
As the title suggests, the APR was very long and caused the content to overflow. To fix this, I utilized the rounding utility function to round it to two decimal places. As usual, below you can find an image of the updated component:
![fixed-browse-card](https://user-images.githubusercontent.com/17186604/176920846-2718b56e-ec2a-417c-a698-3b1b16354015.PNG)

