### PR TITLE
Added formatUSDAuto to better format currency

### DIFF
--- a/src/components/browse/BrowseCard.tsx
+++ b/src/components/browse/BrowseCard.tsx
@@ -28,7 +28,7 @@ import {
 import InvestedTypes from '../common/InvestedTypes';
 import TokenPairIcons from '../common/TokenPairIcons';
 import {
-  formatUSDCompact,
+  formatUSDAuto,
   roundPercentage,
 } from '../../util/Numbers';
 import { Display, Text } from '../common/Typography';
@@ -276,7 +276,7 @@ export default function BrowseCard(props: BrowseCardProps) {
               24H Uniswap Volume
             </Text>
             <Text size='XL' weight='medium'>
-              {formatUSDCompact(uniswapVolume)}
+              {formatUSDAuto(uniswapVolume)}
             </Text>
           </InfoCategoryContainer>
           <InfoCategoryContainer>
@@ -292,7 +292,7 @@ export default function BrowseCard(props: BrowseCardProps) {
               TVL
             </Text>
             <Text size='XL' weight='medium'>
-              {formatUSDCompact(poolStats?.total_value_locked || 0)}
+              {formatUSDAuto(poolStats?.total_value_locked || 0)}
             </Text>
           </InfoCategoryContainer>
         </ResponsiveBodySubContainer>

--- a/src/components/poolstats/PoolPositionWidget.tsx
+++ b/src/components/poolstats/PoolPositionWidget.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import tw from 'twin.macro';
 import { BlendPoolMarkers } from '../../data/BlendPoolMarkers';
 import { RESPONSIVE_BREAKPOINT_MD } from '../../data/constants/Breakpoints';
-import { formatUSD } from '../../util/Numbers';
 import { PercentChange } from '../common/PercentChange';
 import { Display, Text } from '../common/Typography';
 import WidgetHeading from '../common/WidgetHeading';

--- a/src/components/poolstats/PoolStatsWidget.tsx
+++ b/src/components/poolstats/PoolStatsWidget.tsx
@@ -4,7 +4,7 @@ import tw from 'twin.macro';
 import { formatDistance } from 'date-fns';
 import { BlendPoolContext } from '../../data/context/BlendPoolContext';
 import { OffChainPoolStats } from '../../data/PoolStats';
-import { formatUSDCompact, roundPercentage } from '../../util/Numbers';
+import { formatUSDAuto, roundPercentage } from '../../util/Numbers';
 import { Display, Text } from '../common/Typography';
 import WidgetHeading from '../common/WidgetHeading';
 
@@ -88,7 +88,7 @@ export default function PoolStatsWidget(props: PoolStatsWidgetProps) {
             weight='semibold'
             color={POOL_STAT_VALUE_TEXT_COLOR}
           >
-            {uniswapVolume !== null ? formatUSDCompact(uniswapVolume) : '--'}
+            {formatUSDAuto(uniswapVolume, '--')}
           </Display>
         </PoolStat>
         <PoolStat>
@@ -116,7 +116,7 @@ export default function PoolStatsWidget(props: PoolStatsWidgetProps) {
             weight='semibold'
             color={POOL_STAT_VALUE_TEXT_COLOR}
           >
-            {offChainPoolStats ? formatUSDCompact(offChainPoolStats.total_value_locked) : '--'}
+            {formatUSDAuto(offChainPoolStats?.total_value_locked || null, '--')}
           </Display>
         </PoolStat>
         <PoolStat>

--- a/src/components/portfolio/ExternalPortfolioCard.tsx
+++ b/src/components/portfolio/ExternalPortfolioCard.tsx
@@ -8,7 +8,7 @@ import {
   RESPONSIVE_BREAKPOINT_SM
 } from '../../data/constants/Breakpoints';
 import { TokenData } from '../../data/TokenData';
-import { formatUSD } from '../../util/Numbers';
+import { formatUSDAuto } from '../../util/Numbers';
 import { OutlinedGradientButtonWithIcon } from '../common/Buttons';
 import FeeTierContainer from '../common/FeeTierContainer';
 import { PercentChange } from '../common/PercentChange';
@@ -94,7 +94,7 @@ export default function ExternalPortfolioCard(
             Estimated Value
           </Text>
           <ValuePercentContainer>
-            <ValueText>{formatUSD(estimatedValue)}</ValueText>
+            <ValueText>{formatUSDAuto(estimatedValue)}</ValueText>
             <PercentChange percent={percentageChange} />
           </ValuePercentContainer>
         </BodySubContainer>

--- a/src/components/portfolio/PortfolioCard.tsx
+++ b/src/components/portfolio/PortfolioCard.tsx
@@ -19,7 +19,7 @@ import InvestedTypes from '../common/InvestedTypes';
 import TokenPairIcons from '../common/TokenPairIcons';
 import { PercentChange } from '../common/PercentChange';
 import { Display, Text } from '../common/Typography';
-import { formatUSD } from '../../util/Numbers';
+import { formatUSDAuto } from '../../util/Numbers';
 
 const CARD_BODY_BG_COLOR = 'rgba(13, 23, 30, 1)';
 const TOKEN_PAIR_FIGURE_COLOR = 'rgba(255, 255, 255, 0.6)';
@@ -240,7 +240,7 @@ export default function PortfolioCard(props: PortfolioCardProps) {
             Estimated Value
           </Text>
           <div className='flex gap-2 items-center'>
-            <ValueText>{formatUSD(estimatedValue)}</ValueText>
+            <ValueText>{formatUSDAuto(estimatedValue)}</ValueText>
             <PercentChange percent={percentageChange} />
           </div>
         </BodySubContainer>

--- a/src/util/Numbers.ts
+++ b/src/util/Numbers.ts
@@ -25,18 +25,44 @@ export function prettyFormatBalance(amount?: Big, decimals?: number): string {
   return amount.div(String1E(decimals)).toFixed(decimals > 6 ? 4 : 2);
 }
 
-export function formatUSD(amount: number | null): string {
+/**
+ * 
+ * @param amount the amount of money in USD to format
+ * @param placeholder the placeholder to use if the amount is null
+ * @returns a formatted string representing the amount of money in USD
+ */
+export function formatUSD(amount: number | null, placeholder='-'): string {
   if (amount === null) {
-    return '-';
+    return placeholder;
   }
   return amount.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
 }
 
-export function formatUSDCompact(amount: number | null): string {
+/**
+ * 
+ * @param amount the amount of money in USD to format
+ * @param placeholder the placeholder to use if the amount is null
+ * @returns a compact, formatted string representing the amount of money in USD
+ */
+export function formatUSDCompact(amount: number | null, placeholder='-'): string {
   if (amount === null) {
-    return '-';
+    return placeholder;
   }
   return compactCurrencyFormatter.format(amount);
+}
+
+/**
+ * 
+ * @param amount the amount of money in USD to format
+ * @param placeholder the placeholder to use if the amount is null
+ * @returns a formatted string representing the amount of money in USD using 
+ * either the compact or regular format depending on the amount
+ */
+export function formatUSDAuto(amount: number | null, placeholder='-'): string {
+  if (amount && amount < 1000) {
+    return formatUSD(amount, placeholder);
+  }
+  return formatUSDCompact(amount, placeholder);
 }
 
 /**


### PR DESCRIPTION
A simple change that aims to format money in the best possible way based on the amount. If the amount is less than $1,000, it will be formatted normally similar to `$15.25` or `$132.94`. If the amount is greater than or equal to $1,000, it will be formatted in a compact way similar to `52.3K` or `436M`.