### PR TITLE
Added new spinners for pool loading

### DIFF
--- a/src/components/common/Spinner.tsx
+++ b/src/components/common/Spinner.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const ALT_SPINNER_SIZES = {
+  S: 30,
+  M: 50,
+  L: 70,
+};
+
+const IOS_STYLE_SPINNER_SIZES = {
+  S: 0.5,
+  M: 0.75,
+  L: 1,
+};
+
+export const AltSpinner = styled.div.attrs(
+  (props: { size?: 'S' | 'M' | 'L' }) => props
+)`
+  --size: ${(props) => ALT_SPINNER_SIZES[props.size || 'L']}px;
+  --offset: ${(props) => ALT_SPINNER_SIZES[props.size || 'L'] / 2}px;
+  position: absolute;
+  width: var(--size);
+  height: var(--size);
+  top: calc(50% - var(--offset));
+  left: calc(50% - var(--offset));
+  border-radius: 50%;
+  border-top: 5px solid #63b59a;
+  border-right: 5px solid transparent;
+  animation: alt-spin 1s linear infinite;
+
+  @keyframes alt-spin {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+const IOSStyleSpinnerWrapper = styled.div.attrs(
+  (props: { size: 'S' | 'M' | 'L' }) => props
+)`
+  span {
+    --translate-y: ${(props) =>
+      `calc(-30px * ${IOS_STYLE_SPINNER_SIZES[props.size]})`};
+    --width: ${(props) => `calc(8px * ${IOS_STYLE_SPINNER_SIZES[props.size]})`};
+    --height: ${(props) =>
+      `calc(20px * ${IOS_STYLE_SPINNER_SIZES[props.size]})`};
+    --offset-left: ${(props) =>
+      `calc(50% - calc(8px / 2 * ${IOS_STYLE_SPINNER_SIZES[props.size]}))`};
+    --offset-top: ${(props) =>
+      `calc(50% - calc(20px / 2 * ${IOS_STYLE_SPINNER_SIZES[props.size]}))`};
+    display: block;
+    position: absolute;
+    left: var(--offset-left);
+    top: var(--offset-top);
+    width: var(--width);
+    height: var(--height);
+    background: #fff;
+    border-radius: 4px;
+
+    &:nth-child(1) {
+      transform: rotate(0deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: 0s;
+    }
+
+    &:nth-child(2) {
+      transform: rotate(30deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -1.1s;
+    }
+
+    &:nth-child(3) {
+      transform: rotate(60deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -1s;
+    }
+
+    &:nth-child(4) {
+      transform: rotate(90deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.9s;
+    }
+
+    &:nth-child(5) {
+      transform: rotate(120deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.8s;
+    }
+
+    &:nth-child(6) {
+      transform: rotate(150deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.7s;
+    }
+
+    &:nth-child(7) {
+      transform: rotate(180deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.6s;
+    }
+
+    &:nth-child(8) {
+      transform: rotate(210deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.5s;
+    }
+
+    &:nth-child(9) {
+      transform: rotate(240deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.4s;
+    }
+
+    &:nth-child(10) {
+      transform: rotate(270deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.3s;
+    }
+
+    &:nth-child(11) {
+      transform: rotate(300deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.2s;
+    }
+
+    &:nth-child(12) {
+      transform: rotate(330deg) translateY(var(--translate-y));
+      animation: spin 1.2s infinite linear;
+      animation-delay: -0.1s;
+    }
+  }
+
+  @keyframes spin {
+    0% {
+      opacity: 1;
+    }
+
+    100% {
+      opacity: 0.25;
+    }
+  }
+`;
+
+export type IOSStyleSpinnerProps = {
+  size?: 'S' | 'M' | 'L';
+};
+
+export function IOSStyleSpinner(props: IOSStyleSpinnerProps) {
+  return (
+    <IOSStyleSpinnerWrapper size={props.size || 'L'}>
+      {Array.from({ length: 12 }).map((_, i) => (
+        <span key={i} />
+      ))}
+    </IOSStyleSpinnerWrapper>
+  );
+}

--- a/src/pages/BlendPoolPage.tsx
+++ b/src/pages/BlendPoolPage.tsx
@@ -176,8 +176,7 @@ export default function BlendPoolPage(props: BlendPoolPageProps) {
   const [{ data: accountData }] = useAccount({ fetchEns: true });
   const walletIsConnected = accountData?.address !== undefined;
 
-  let a = true;
-  if (!poolData || a) {
+  if (!poolData) {
     if (params.pooladdress) {
       fetchPoolData(params.pooladdress);
     }

--- a/src/pages/BlendPoolPage.tsx
+++ b/src/pages/BlendPoolPage.tsx
@@ -31,12 +31,21 @@ import { useAccount } from 'wagmi';
 import { FeeTier } from '../data/BlendPoolMarkers';
 import { theGraphUniswapV3Client } from '../App';
 import { getUniswapVolumeQuery } from '../util/GraphQL';
+import { IOSStyleSpinner } from '../components/common/Spinner';
 
 const ABOUT_MESSAGE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 
 type PoolParams = {
   pooladdress: string;
 };
+
+const LoaderWrapper = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+`;
 
 const PoolBodyWrapper = styled.div`
   display: grid;
@@ -101,6 +110,7 @@ export default function BlendPoolPage(props: BlendPoolPageProps) {
   const params = useParams<PoolParams>();
   const navigate = useNavigate();
   const isGTMediumScreen = useMediaQuery(RESPONSIVE_BREAKPOINTS.MD);
+  const isGTSmallScreen = useMediaQuery(RESPONSIVE_BREAKPOINTS.SM);
 
   const { poolDataMap, fetchPoolData } = useContext(BlendTableContext);
 
@@ -166,11 +176,16 @@ export default function BlendPoolPage(props: BlendPoolPageProps) {
   const [{ data: accountData }] = useAccount({ fetchEns: true });
   const walletIsConnected = accountData?.address !== undefined;
 
-  if (!poolData) {
+  let a = true;
+  if (!poolData || a) {
     if (params.pooladdress) {
       fetchPoolData(params.pooladdress);
     }
-    return <div>Finding pool...</div>;
+    return (
+      <LoaderWrapper>
+        <IOSStyleSpinner size={isGTMediumScreen ? 'L' : isGTSmallScreen ? 'M' : 'S'} />
+      </LoaderWrapper>
+    );
   }
 
   return (


### PR DESCRIPTION
Added two styles of spinner to use for the initial loading of the pool page as well as anything else we may need them for in the future! Hayden mentioned how he wanted something similar to the spinner on iOS, so I added that as well as an AltSpinner as an alternative just in case you want to use a different type. As usual, below I added some images of the new components:

#### Large Screen
![loader-1](https://user-images.githubusercontent.com/17186604/178115373-bce0aca7-5d5a-4bfe-a7ea-b4b1e47f259e.PNG)

#### Medium Screen
![loader-2](https://user-images.githubusercontent.com/17186604/178115375-62d568e0-71b8-40f1-bd23-1b3c2a5a0ac3.PNG)

#### Small Screen
![loader-3](https://user-images.githubusercontent.com/17186604/178115379-4e2cedbe-49fe-49bb-a06e-8f8962e06a7d.PNG)

#### Large Screen
![alt-loader-1](https://user-images.githubusercontent.com/17186604/178115383-bf830534-ab5a-4fb4-b652-212385a84a01.PNG)

#### Medium Screen
![alt-loader-2](https://user-images.githubusercontent.com/17186604/178115386-e272df74-6db9-4adc-ad2b-2bb44c8e1c61.PNG)

#### Small Screen
![alt-loader-3](https://user-images.githubusercontent.com/17186604/178115388-deacdd29-eb82-46c4-959e-a654963a7eb8.PNG)

