### PR TITLE
Adding missed semicolon

### DIFF
--- a/src/components/graph/BlendGraph.tsx
+++ b/src/components/graph/BlendGraph.tsx
@@ -58,7 +58,7 @@ const LegendItemBoxDashed = styled.div`
   margin-bottom: 3.5px;
   background-color: clear;
   border-bottom: 3px dotted;
-  border-color: ${(props) => props.color}
+  border-color: ${(props) => props.color};
 `;
 
 type BlendGraphLegendProps = {


### PR DESCRIPTION
As the title suggests, I added a missing semicolon. The reason I thought this was worth doing is that it breaks my linter locally.