### PR TITLE
Added a temporary fix to the 1m graph range

### DIFF
--- a/src/components/allocationgraph/BlendAllocationGraph.tsx
+++ b/src/components/allocationgraph/BlendAllocationGraph.tsx
@@ -185,8 +185,11 @@ export default function BlendAllocationGraph(props: BlendAllocationGraphProps) {
               }
               if (mounted) {
                 if (buttonIdxToText(activeButton).toLowerCase() === '1m') {
+                  // since the endDate isn't necessarily the current date
+                  const endDate = new Date(updatedData[updatedData.length - 1]['x']);
+                  const oneMonthBeforeEnd = subMonths(endDate, 1);
                   updatedData = updatedData.filter(
-                    (d) => new Date(d['x']) >= fromDate
+                    (d) => new Date(d['x']) >= oneMonthBeforeEnd
                   );
                 }
                 setData(updatedData);

--- a/src/components/browse/BrowseCard.tsx
+++ b/src/components/browse/BrowseCard.tsx
@@ -281,7 +281,7 @@ export default function BrowseCard(props: BrowseCardProps) {
           </InfoCategoryContainer>
           <InfoCategoryContainer>
             <Text size='S' weight='medium' color={INFO_CATEGORY_TEXT_COLOR}>
-              APR (30d avg)
+              APR (14d avg)
             </Text>
             <Text size='XL' weight='medium'>
               {roundPercentage(100 * (poolStats?.annual_percentage_rate ?? 0))}%

--- a/src/components/poolstats/PoolStatsWidget.tsx
+++ b/src/components/poolstats/PoolStatsWidget.tsx
@@ -50,7 +50,7 @@ export default function PoolStatsWidget(props: PoolStatsWidgetProps) {
       <PoolStatsWidgetGrid>
         <PoolStat>
           <Text size='S' weight='medium' color={POOL_STAT_LABEL_TEXT_COLOR}>
-            APR (30d avg)
+            APR (14d avg)
           </Text>
           <Display
             size='S'


### PR DESCRIPTION
Since the 1M endpoint for the api seems to be slow to the point where it is unusable currently, we can use the 3M data to display a general idea of the 1M data by trimming the data to only include the last month. Ideally, this is a temporary fix until we can get the endpoint working correctly.