### PR TITLE
Fix the fee tier border on mobile

### DIFF
--- a/src/components/browse/BrowseCard.tsx
+++ b/src/components/browse/BrowseCard.tsx
@@ -106,7 +106,7 @@ const FeeTierContainer = styled.div`
   padding: 8px 16px;
   background: ${FEE_TIER_BG_COLOR};
   color: ${FEE_TIER_TEXT_COLOR};
-  outline: 2px solid ${FEE_TIER_OUTLINE_COLOR};
+  box-shadow: 0px 0px 0px 2px ${FEE_TIER_OUTLINE_COLOR};
   border-radius: 100px;
 `;
 


### PR DESCRIPTION
Hayden pointed out to me that the fee tier border on mobile appeared to be broken as seen here:
![feetier-border-broken](https://user-images.githubusercontent.com/17186604/178130620-d018495e-46cd-409d-b8d9-2fa0d51342b7.png)

I believe the issue is stemming from the outline not working well with the border-radius on all devices, so I switched it to a box-shadow which should play better with the border-radius across all devices. Here is an image of the updated component (not on mobile).
![feetier-border-fix](https://user-images.githubusercontent.com/17186604/178130661-d0a3f45f-797e-469f-bced-c80933fa5a22.PNG)

