### PR TITLE
Cleaning up pool position logic (fixing errors)

### DIFF
--- a/src/components/poolstats/PoolPositionWidget.tsx
+++ b/src/components/poolstats/PoolPositionWidget.tsx
@@ -96,14 +96,15 @@ function findNearestElementByTime<T extends Timestamp>(arr: T[], timestamp: stri
 }
 
 export type PoolPositionWidgetProps = {
+  walletIsConnected: boolean;
   poolData: BlendPoolMarkers;
   offChainPoolStats: OffChainPoolStats | undefined;
-  accountData: AccountData;
+  accountData: AccountData | undefined;
 };
 
 export default function PoolPositionWidget(props: PoolPositionWidgetProps) {
 
-  const { poolData, offChainPoolStats, accountData } = props;
+  const { walletIsConnected, poolData, offChainPoolStats, accountData } = props;
   const { poolStats } = useContext(BlendPoolContext);
 
   // const [{ data: accountData }] = useAccount();
@@ -216,14 +217,18 @@ export default function PoolPositionWidget(props: PoolPositionWidgetProps) {
         }
       ));
     }
-    if (offChainPoolStats && poolStats && accountShareBalance && accountData) {
+    if (walletIsConnected && offChainPoolStats && poolStats && accountShareBalance && accountData && !accountStats) {
       fetchAccountStats(offChainPoolStats, poolStats, accountShareBalance, accountData);
     }
     return () => {
       mounted = false;
     }
-  }, [accountData, accountShareBalance, offChainPoolStats, poolData, poolStats]);
+  }, [accountData, accountShareBalance, accountStats, offChainPoolStats, poolData, poolStats, walletIsConnected]);
   
+  if (!walletIsConnected) {
+    return null;
+  }
+
   return (
     <Wrapper>
       <WidgetHeading>Your Position</WidgetHeading>

--- a/src/components/poolstats/PoolPositionWidget.tsx
+++ b/src/components/poolstats/PoolPositionWidget.tsx
@@ -144,8 +144,7 @@ export default function PoolPositionWidget(props: PoolPositionWidgetProps) {
       axios.all([getEvents, getPoolReturns, getPrices0, getPrices1, getPoolReturns3M, getPrices03M, getPrices13M]).then(
         axios.spread((eventData, poolReturnsData, price0Data, price1Data, poolReturnsData3M, price0Data3M, price1Data3M) => {
           const events = eventData.data.result;
-          // If there are no events, we can't calculate anything
-          if (events.length === 0) return;
+          if (!Array.isArray(events)) return;
           const transfers = events.filter((ev: any) => ev.topics[0] === '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef');
 
           let poolReturns = (poolReturnsData.data as PoolReturns).concat(...(poolReturnsData3M.data as PoolReturns));

--- a/src/components/poolstats/PoolPositionWidget.tsx
+++ b/src/components/poolstats/PoolPositionWidget.tsx
@@ -144,6 +144,8 @@ export default function PoolPositionWidget(props: PoolPositionWidgetProps) {
       axios.all([getEvents, getPoolReturns, getPrices0, getPrices1, getPoolReturns3M, getPrices03M, getPrices13M]).then(
         axios.spread((eventData, poolReturnsData, price0Data, price1Data, poolReturnsData3M, price0Data3M, price1Data3M) => {
           const events = eventData.data.result;
+          // If there are no events, we can't calculate anything
+          if (events.length === 0) return;
           const transfers = events.filter((ev: any) => ev.topics[0] === '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef');
 
           let poolReturns = (poolReturnsData.data as PoolReturns).concat(...(poolReturnsData3M.data as PoolReturns));

--- a/src/pages/BlendPoolPage.tsx
+++ b/src/pages/BlendPoolPage.tsx
@@ -27,7 +27,7 @@ import { GetTokenData } from '../data/TokenData';
 import { ReactComponent as OpenIcon } from '../assets/svg/open.svg';
 import tw from 'twin.macro';
 import useMediaQuery from '../data/hooks/UseMediaQuery';
-import { useAccount } from 'wagmi';
+import { Connector, useAccount } from 'wagmi';
 import { FeeTier } from '../data/BlendPoolMarkers';
 import { theGraphUniswapV3Client } from '../App';
 import { getUniswapVolumeQuery } from '../util/GraphQL';
@@ -38,6 +38,15 @@ const ABOUT_MESSAGE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 type PoolParams = {
   pooladdress: string;
 };
+
+export type AccountData = {
+  address: string;
+  connector: Connector<any, any> | undefined;
+    ens: {
+        avatar: string | null | undefined;
+        name: string;
+    } | undefined;
+}
 
 const LoaderWrapper = styled.div`
   position: absolute;
@@ -231,6 +240,7 @@ export default function BlendPoolPage(props: BlendPoolPageProps) {
           {walletIsConnected && <PoolPositionWidget
             poolData={poolData}
             offChainPoolStats={offChainPoolStats}
+            accountData={accountData}
           />}
           <PoolStatsWidget
             offChainPoolStats={offChainPoolStats}

--- a/src/pages/BlendPoolPage.tsx
+++ b/src/pages/BlendPoolPage.tsx
@@ -237,11 +237,12 @@ export default function BlendPoolPage(props: BlendPoolPageProps) {
               />
             </GridExpandingDiv>
           )}
-          {walletIsConnected && <PoolPositionWidget
+          <PoolPositionWidget
+            walletIsConnected={walletIsConnected}
             poolData={poolData}
             offChainPoolStats={offChainPoolStats}
             accountData={accountData}
-          />}
+          />
           <PoolStatsWidget
             offChainPoolStats={offChainPoolStats}
             uniswapVolume={uniswapVolume}


### PR DESCRIPTION
TLDR: I cleaned up the logic in the pool position widget and hopefully reduced the number of API calls being sent out to etherscan.

I noticed some errors in the console due to rate limiting from etherscan resulting in a string as result rather than the array we expected. To fix this, I added a guard clause to ensure the result is an array before we try to do anything with it. With that being said, this does not address the underlying problem which is that the etherscan API is being called enough to rate limit us. After doing a good bit of looking into it, I wasn't able to come up with a perfect solution, but I did clean up the logic a good deal and got it to send fewer API calls for me locally (although it may be different for different people). One thing I noticed is that when the screen is resized passed certain breakpoints (used for responsiveness), the component is re-rendered (as it should be), but more API calls are also sent out (which is not ideal). I do not think this poses a big issue but would like to continue to think about ways to prevent this (without just adding even more checks).