### PR TITLE
Fixing memory leaks in Withdraw and Deposit tabs

### DIFF
--- a/src/components/pool/WithdrawTab.tsx
+++ b/src/components/pool/WithdrawTab.tsx
@@ -167,6 +167,11 @@ export default function WithdrawTab(props: WithdrawTabProps) {
 
   // Determine button state
   useEffect(() => {
+    let mounted = true;
+
+    if (!mounted) {
+      return;
+    }
     if (isTransactionPending) {
       setButtonState(ButtonState.PENDING_TRANSACTION);
     } else if (!maxShares || !poolStats || sharesBig.eq(0)) {
@@ -177,6 +182,9 @@ export default function WithdrawTab(props: WithdrawTabProps) {
       setButtonState(ButtonState.INSUFFICIENT_SHARES);
     } else {
       setButtonState(ButtonState.READY);
+    }
+    return () => {
+      mounted = false;
     }
   }, [
     isTransactionPending,


### PR DESCRIPTION
I am not sure how this has been sitting under our noses this whole time but after noticing some errors, I took a look, and sure enough, we had two memory leaks due to setting state after the components were unmounted. These are now fixed and should no longer cause us any trouble.