### PR TITLE
Began integrating the portfolio page

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/styled-components": "^5.1.21",
     "axios": "^0.25.0",
+    "axios-rate-limit": "^1.3.0",
     "big.js": "^6.1.1",
     "color.js": "^1.2.0",
     "date-fns": "^2.28.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,13 @@ import {
   gql,
 } from '@apollo/react-hooks';
 
+export const theGraphUniswapV2Client = new ApolloClient({
+  link: new HttpLink({
+    uri: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2',
+  }),
+  cache: new InMemoryCache(),
+});
+
 export const theGraphUniswapV3Client = new ApolloClient({
   link: new HttpLink({
     uri: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3',
@@ -104,6 +111,7 @@ function App() {
                       element={<Navigate replace to='/blend/pools' />}
                     />
                   </Route>
+                  <Route path='/portfolio' element={<PortfolioPage />} />
                   { // Devmode-only example page routing
                     IS_DEV && (
                       <>

--- a/src/components/graph/PortfolioGraph.tsx
+++ b/src/components/graph/PortfolioGraph.tsx
@@ -17,6 +17,7 @@ import { CombinedPercentChange } from '../common/PercentChange';
 import { Display, Text } from '../common/Typography';
 import Graph from './Graph';
 import GraphButtons, { buttonIdxToText } from './GraphButtons';
+import { PortfolioGraphPlaceholder } from './PortfolioGraphPlaceholder';
 import PortfolioGraphTooltip, {
   PORTFOLIO_TOOLTIP_WIDTH,
 } from './tooltips/PortfolioGraphTooltip';
@@ -187,7 +188,7 @@ function generateEmptyData(fromDate: Date, toDate: Date, activeButton: number) {
 }
 
 export type PortfolioGraphProps = {
-  accountAddress: string;
+  accountAddress: string | null;
 };
 export default function PortfolioGraph(props: PortfolioGraphProps) {
   const { accountAddress } = props;
@@ -239,7 +240,7 @@ export default function PortfolioGraph(props: PortfolioGraphProps) {
 
   useEffect(() => {
     let mounted = true;
-    const fetchPoolStats = async () => {
+    const fetchPoolStats = async (accountAddress: string) => {
       const getShareBalances = makeRequest(
         `${API_URL}/share_balances/${accountAddress}/1/${buttonIdxToText(
           activeButton
@@ -338,7 +339,9 @@ export default function PortfolioGraph(props: PortfolioGraphProps) {
           }
         });
     };
-    fetchPoolStats();
+    if (accountAddress) {
+      fetchPoolStats(accountAddress);
+    }
     return () => {
       mounted = false;
     };
@@ -374,9 +377,7 @@ export default function PortfolioGraph(props: PortfolioGraphProps) {
       </GraphButtonsWrapper>
       {graphLoading && (
         <GraphPlaceholderWrapper>
-          <Text size='M' weight='medium'>
-            Loading...
-          </Text>
+          <PortfolioGraphPlaceholder />
         </GraphPlaceholderWrapper>
       )}
       {!graphLoading && graphError && (

--- a/src/components/graph/PortfolioGraphPlaceholder.tsx
+++ b/src/components/graph/PortfolioGraphPlaceholder.tsx
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+import tw from 'twin.macro';
+import {
+  RESPONSIVE_BREAKPOINT_MD,
+  RESPONSIVE_BREAKPOINT_SM,
+  RESPONSIVE_BREAKPOINT_XS,
+} from '../../data/constants/Breakpoints';
+
+export const PortfolioGraphPlaceholder = styled.div`
+  ${tw`flex flex-col items-start justify-evenly`}
+  width: 100%;
+  height: 225.5px;
+  background: #0d171e;
+  background-image: linear-gradient(
+    to right,
+    #0d171e 0%,
+    #131f28 20%,
+    #0d171e 40%,
+    #0d171e 100%
+  );
+  background-repeat: no-repeat;
+  background-size: 100% 222.5px;
+  display: inline-block;
+  animation: portfolioGraphShimmer 1s forwards linear infinite;
+  overflow: hidden;
+  position: relative;
+
+  @keyframes portfolioGraphShimmer {
+    0% {
+      background-position: -1400px 0;
+    }
+    100% {
+      background-position: 1400px 0;
+    }
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
+    @keyframes portfolioGraphShimmer {
+      0% {
+        background-position: -1200px 0;
+      }
+      100% {
+        background-position: 1200px 0;
+      }
+    }
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+    @keyframes portfolioGraphShimmer {
+      0% {
+        background-position: -768px 0;
+      }
+      100% {
+        background-position: 768px 0;
+      }
+    }
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_XS}) {
+    @keyframes portfolioGraphShimmer {
+      0% {
+        background-position: -480px 0;
+      }
+      100% {
+        background-position: 480px 0;
+      }
+    }
+  }
+`;

--- a/src/components/header/ConnectWalletButton.tsx
+++ b/src/components/header/ConnectWalletButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { CloseableModal } from '../common/Modal';
 
-import { useAccount, useConnect } from 'wagmi';
+import { useConnect } from 'wagmi';
 import { FormatAddress } from '../../util/FormatAddress';
 import {
   FilledStylizedButton,
@@ -11,16 +11,15 @@ import { mapConnectorNameToIcon } from './ConnectorIconMap';
 import { Text } from '../common/Typography';
 
 export type ConnectWalletButtonProps = {
+  accountData: any;
+  disconnect: () => void;
   buttonStyle?: 'secondary' | 'tertiary';
 };
 
 export default function ConnectWalletButton(props: ConnectWalletButtonProps) {
+  const { accountData, disconnect } = props;
   const [modalOpen, setModalOpen] = useState<boolean>(false);
-
   const [{ data: connectData, error: connectError }, connect] = useConnect();
-  const [{ data: accountData }, disconnect] = useAccount({
-    fetchEns: true,
-  });
 
   const ensName: string | undefined = accountData?.ens?.name;
   const formattedAddr = accountData ? FormatAddress(accountData.address) : '';

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -9,11 +9,13 @@ import useMediaQuery from '../../data/hooks/UseMediaQuery';
 import { Text } from '../common/Typography';
 import ConnectWalletButton from './ConnectWalletButton';
 import { IS_DEV } from '../../util/Env';
+import { useAccount } from 'wagmi';
 
 type MenuItem = {
   title: string;
   name: string;
   url: string;
+  onlyShowIfConnected?: boolean;
 };
 
 const menuItems: MenuItem[] = [
@@ -22,6 +24,12 @@ const menuItems: MenuItem[] = [
     name: 'blend',
     url: '/blend',
   },
+  {
+    title: 'Portfolio',
+    name: 'portfolio',
+    url: '/portfolio',
+    onlyShowIfConnected: true,
+  }
 ];
 
 if (IS_DEV) {
@@ -78,6 +86,9 @@ const NavDropdown = styled.div`
 `;
 
 export default function Header() {
+  const [{ data: accountData }, disconnect] = useAccount({
+    fetchEns: true,
+  });
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const toggleNavDropdown = () => {
     setIsMenuOpen(!isMenuOpen);
@@ -97,20 +108,22 @@ export default function Header() {
           <>
             <VerticalDivider />
             <div className='flex flex-row align-middle items-center h-full text-md'>
-              {menuItems.map((menuitem, index) => (
+              {menuItems.map((menuItem, index) => (
                 <React.Fragment key={index}>
-                  <StyledNavLink
-                    size='M'
-                    weight='medium'
-                    color='rgba(75, 105, 128, 1)'
-                    as={NavLink}
-                    id={`${menuitem.name}-nav-link`}
-                    to={menuitem.url}
-                    key={menuitem.name}
-                  >
-                    {menuitem.title}
-                  </StyledNavLink>
-                  <VerticalDivider />
+                  <div className={`${!menuItem.onlyShowIfConnected || accountData ? 'flex' : 'hidden'}`}>
+                    <StyledNavLink
+                      size='M'
+                      weight='medium'
+                      color='rgba(75, 105, 128, 1)'
+                      as={NavLink}
+                      id={`${menuItem.name}-nav-link`}
+                      to={menuItem.url}
+                      key={menuItem.name}
+                    >
+                      {menuItem.title}
+                    </StyledNavLink>
+                    <VerticalDivider />
+                  </div>
                 </React.Fragment>
               ))}
             </div>
@@ -129,31 +142,33 @@ export default function Header() {
       )}
       {!isGTSmallScreen && isMenuOpen && (
         <NavDropdown>
-          {menuItems.map((menuitem, index) => (
+          {menuItems.map((menuItem, index) => (
             <React.Fragment key={index}>
-              <StyledNavLink
-                size='M'
-                weight='medium'
-                color='rgba(75, 105, 128, 1)'
-                className='mobile w-full text-center'
-                as={NavLink}
-                id={`${menuitem.name}-nav-link`}
-                to={menuitem.url}
-                key={menuitem.name}
-                onClick={toggleNavDropdown}
-              >
-                {menuitem.title}
-              </StyledNavLink>
+              <div className={`${!menuItem.onlyShowIfConnected || accountData ? 'w-full flex' : 'hidden'}`}>
+                <StyledNavLink
+                  size='M'
+                  weight='medium'
+                  color='rgba(75, 105, 128, 1)'
+                  className='mobile w-full text-center'
+                  as={NavLink}
+                  id={`${menuItem.name}-nav-link`}
+                  to={menuItem.url}
+                  key={menuItem.name}
+                  onClick={toggleNavDropdown}
+                >
+                  {menuItem.title}
+                </StyledNavLink>
+              </div>
             </React.Fragment>
           ))}
           <div className='w-full'>
-            <ConnectWalletButton buttonStyle='tertiary' />
+            <ConnectWalletButton accountData={accountData} disconnect={disconnect} buttonStyle='tertiary' />
           </div>
         </NavDropdown>
       )}
       {isGTSmallScreen && (
         <div className='mr-8'>
-          <ConnectWalletButton />
+          <ConnectWalletButton accountData={accountData} disconnect={disconnect} />
         </div>
       )}
     </Nav>

--- a/src/components/pool/ConnectWallet.tsx
+++ b/src/components/pool/ConnectWallet.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useAccount } from 'wagmi';
 import DepositIllustration from '../../assets/svg/deposit_illustration.svg';
 import { Display, Text } from '../common/Typography';
 import ConnectWalletButton from '../header/ConnectWalletButton';
@@ -25,6 +26,9 @@ const Wrapper = styled.div`
 `;
 
 export default function ConnectWallet() {
+  const [{ data: accountData }, disconnect] = useAccount({
+    fetchEns: true,
+  });
   return (
     <Wrapper>
       <div className='flex items-center justify-center'>
@@ -36,7 +40,7 @@ export default function ConnectWallet() {
           By investing with Aloe, you will be able to earn trading fees on Uniswap, collect interest from other protocols, and autonomously manage your portfolio.
         </Text>
       </div>
-      <ConnectWalletButton buttonStyle='secondary' />
+      <ConnectWalletButton accountData={accountData} disconnect={disconnect} buttonStyle='secondary' />
     </Wrapper>
   );
 }

--- a/src/components/portfolio/ExternalPortfolioCard.tsx
+++ b/src/components/portfolio/ExternalPortfolioCard.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import tw from 'twin.macro';
 import { ReactComponent as MigrateIcon } from '../../assets/svg/migrate.svg';
-import { FeeTier } from '../../data/BlendPoolMarkers';
 import {
   RESPONSIVE_BREAKPOINT_MD,
   RESPONSIVE_BREAKPOINT_SM
@@ -10,7 +9,6 @@ import {
 import { TokenData } from '../../data/TokenData';
 import { formatUSDAuto } from '../../util/Numbers';
 import { OutlinedGradientButtonWithIcon } from '../common/Buttons';
-import FeeTierContainer from '../common/FeeTierContainer';
 import { PercentChange } from '../common/PercentChange';
 import TokenPairIcons from '../common/TokenPairIcons';
 import { Display, Text } from '../common/Typography';
@@ -59,10 +57,18 @@ const EndAlignedBodySubContainer = styled(BodySubContainer)`
   }
 `;
 
+const ExternalPositionNameContainer = styled.div`
+  ${tw`flex flex-col items-center justify-center`}
+  padding: 8px 24px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 100px;
+`;
+
 export type ExternalPortfolioCardProps = {
   token0: TokenData;
   token1: TokenData;
-  uniswapFeeTier: FeeTier;
+  externalPositionName: string;
   estimatedValue: number;
   percentageChange: number;
 };
@@ -70,7 +76,7 @@ export type ExternalPortfolioCardProps = {
 export default function ExternalPortfolioCard(
   props: ExternalPortfolioCardProps
 ) {
-  const { token0, token1, uniswapFeeTier, estimatedValue, percentageChange } =
+  const { token0, token1, externalPositionName, estimatedValue, percentageChange } =
     props;
   return (
     <ExternalCardWrapper>
@@ -85,7 +91,11 @@ export default function ExternalPortfolioCard(
             token0AltText={`${token0.name}'s Icon`}
             token1AltText={`${token1.name}'s Icon`}
           />
-          <FeeTierContainer feeTier={uniswapFeeTier} />
+          <ExternalPositionNameContainer>
+            <Text size='S' weight='bold' color='rgba(204, 223, 237, 1)'>
+              {externalPositionName}
+            </Text>
+          </ExternalPositionNameContainer>
         </CardSubTitleWrapper>
       </CardTitleWrapper>
       <CardBodyWrapper>

--- a/src/components/portfolio/ExternalPortfolioCard.tsx
+++ b/src/components/portfolio/ExternalPortfolioCard.tsx
@@ -59,7 +59,7 @@ const EndAlignedBodySubContainer = styled(BodySubContainer)`
 
 const ExternalPositionNameContainer = styled.div`
   ${tw`flex flex-col items-center justify-center`}
-  padding: 8px 24px;
+  padding: 8px 16px;
   height: 36px;
   background: rgba(255, 255, 255, 0.1);
   border-radius: 100px;
@@ -92,9 +92,9 @@ export default function ExternalPortfolioCard(
             token1AltText={`${token1.name}'s Icon`}
           />
           <ExternalPositionNameContainer>
-            <Text size='S' weight='bold' color='rgba(204, 223, 237, 1)'>
+            <Display size='XS' weight='medium' color='rgba(204, 223, 237, 1)'>
               {externalPositionName}
-            </Text>
+            </Display>
           </ExternalPositionNameContainer>
         </CardSubTitleWrapper>
       </CardTitleWrapper>

--- a/src/components/portfolio/ExternalPortfolioCardPlaceholder.tsx
+++ b/src/components/portfolio/ExternalPortfolioCardPlaceholder.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import tw from 'twin.macro';
+import {
+  RESPONSIVE_BREAKPOINT_MD,
+  RESPONSIVE_BREAKPOINT_SM,
+} from '../../data/constants/Breakpoints';
+
+export const ExternalPortfolioCardPlaceholder = styled.div`
+${tw`flex flex-col items-start justify-evenly`}
+  width: 100%;
+  height: 150px;
+  background: #0d171e;
+  background-image: linear-gradient(
+    to right,
+    #0d171e 0%,
+    #131f28 20%,
+    #0d171e 40%,
+    #0d171e 100%
+  );
+  background-repeat: no-repeat;
+  background-size: 100% 150px;
+  display: inline-block;
+  animation: externalPortfolioCardShimmer 1s forwards linear infinite;
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+
+  @keyframes externalPortfolioCardShimmer {
+    0% {
+      background-position: -1200px 0;
+    }
+    100% {
+      background-position: 1200px 0;
+    }
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
+    width: 100%;
+    height: 262px;
+    background-size: 100% 262px;
+
+    @keyframes externalPortfolioCardShimmer {
+      0% {
+        background-position: -1040px 0;
+      }
+      100% {
+        background-position: 1040px 0;
+      }
+    }
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+    width: 100%;
+    height: 406.3px;
+    background-size: 100% 406.3px;
+
+    @keyframes externalPortfolioCardShimmer {
+      0% {
+        background-position: -720px 0;
+      }
+      100% {
+        background-position: 720px 0;
+      }
+    }
+  }
+`;

--- a/src/components/portfolio/PortfolioCardPlaceholder.tsx
+++ b/src/components/portfolio/PortfolioCardPlaceholder.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import tw from 'twin.macro';
+import {
+  RESPONSIVE_BREAKPOINT_MD,
+  RESPONSIVE_BREAKPOINT_SM,
+} from '../../data/constants/Breakpoints';
+
+export const PortfolioCardPlaceholder = styled.div`
+${tw`flex flex-col items-start justify-evenly`}
+  width: 100%;
+  height: 150px;
+  background: #0d171e;
+  background-image: linear-gradient(
+    to right,
+    #0d171e 0%,
+    #131f28 20%,
+    #0d171e 40%,
+    #0d171e 100%
+  );
+  background-repeat: no-repeat;
+  background-size: 100% 150px;
+  display: inline-block;
+  animation: portfolioCardShimmer 1s forwards linear infinite;
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+
+  @keyframes portfolioCardShimmer {
+    0% {
+      background-position: -1200px 0;
+    }
+    100% {
+      background-position: 1200px 0;
+    }
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_MD}) {
+    width: 100%;
+    height: 270px;
+    background-size: 100% 270px;
+
+    @keyframes portfolioCardShimmer {
+      0% {
+        background-position: -1040px 0;
+      }
+      100% {
+        background-position: 1040px 0;
+      }
+    }
+  }
+
+  @media (max-width: ${RESPONSIVE_BREAKPOINT_SM}) {
+    width: 100%;
+    height: 431px;
+    background-size: 100% 431px;
+
+    @keyframes portfolioCardShimmer {
+      0% {
+        background-position: -720px 0;
+      }
+      100% {
+        background-position: 720px 0;
+      }
+    }
+  }
+`;

--- a/src/data/TokenData.ts
+++ b/src/data/TokenData.ts
@@ -96,6 +96,10 @@ const TokenDataMap = new Map<string, TokenData>([
   ],
 ]);
 
+export function getTokens(): TokenData[] {
+  return Array.from(TokenDataMap.values());
+}
+
 export function GetTokenData(address: string): TokenData {
   if (TokenDataMap.has(address)) {
     return TokenDataMap.get(address)!;

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import AppPage from '../components/common/AppPage';
 import styled from 'styled-components';
 import tw from 'twin.macro';
@@ -7,13 +7,28 @@ import EmptyPortfolio from '../components/portfolio/EmptyPortfolio';
 import ExternalPortfolioCard from '../components/portfolio/ExternalPortfolioCard';
 import EmptyExternalPortfolio from '../components/portfolio/EmptyExternalPortfolio';
 import { GetTokenData } from '../data/TokenData';
-import { FeeTier } from '../data/BlendPoolMarkers';
+import { BlendPoolMarkers } from '../data/BlendPoolMarkers';
 import { GetSiloData } from '../data/SiloData';
 import { Text } from '../components/common/Typography';
 import PortfolioGraph from '../components/graph/PortfolioGraph';
 import Tooltip from '../components/common/Tooltip';
 import useMediaQuery from '../data/hooks/UseMediaQuery';
 import { RESPONSIVE_BREAKPOINTS } from '../data/constants/Breakpoints';
+import axios from 'axios';
+import rateLimit from 'axios-rate-limit';
+import { BlendTableContext } from '../data/context/BlendTableContext';
+import { theGraphUniswapV2Client } from '../App';
+import { getUniswapPairValueQuery } from '../util/GraphQL';
+import { API_URL } from '../data/constants/Values';
+import { PortfolioCardPlaceholder } from '../components/portfolio/PortfolioCardPlaceholder';
+import { ExternalPortfolioCardPlaceholder } from '../components/portfolio/ExternalPortfolioCardPlaceholder';
+import { useAccount } from 'wagmi';
+
+const http = rateLimit(axios.create(), {
+  maxRequests: 2,
+  perMilliseconds: 1000,
+  maxRPS: 2,
+});
 
 const PORTFOLIO_TITLE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 
@@ -28,79 +43,183 @@ const PortfolioCards = styled.div`
   margin-top: 24px;
 `;
 
+type Position = {
+  pool: BlendPoolMarkers;
+  estimatedValue: number;
+};
+
+type ExternalPosition = Position & {
+  externalPositionName: string;
+};
+
+function poolToUniswapV2Pair(address: string): string {
+  switch (address) {
+    case '0x33cb657e7fd57f1f2d5f392fb78d5fa80806d1b4':
+      return '0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc';
+    case '0xe801c4175a0341e65dfef8f3b79e1889047afebb':
+      return '0xbb2b8038a1640196fbe3e38816f3e67cba72d940';
+    case '0x0b76abb170519c292da41404fdc30bb5bef308fc':
+      return '0x9928e4046d7c6513326ccea028cd3e7a91c7590a';
+    case '0x37dc6fcb5c03d46b097b094785c9fa557aa32fd4':
+      return '0x8ae720a71622e824f576b4a8c03031066548a3b1';
+    case '0x021016fbb4d3aaeaa440508c5e06ce8c1039fccd':
+      return '0xdc00ba87cc2d99468f7f34bc04cbf72e111a32f7';
+    default:
+      return '';
+  }
+}
+
+// const aloeAddress = '0x2b6dbde60278f19c742bd6861aa39e0a565f5aa3'//'0xcf2b7c6bc98bfe0d6138a25a3b6162b51f75e05d';
+// const externalAddress = '0xfae511813cc7a823f95bbc8bfd9aa3c31e6cc52a';
+export type PortfolioPageProps = {
+}; 
 export default function PortfolioPage() {
+  const [{ data: accountData }] = useAccount({
+    fetchEns: true,
+  });
+  const [positionsLoading, setPositionsLoading] = useState(true);
+  const [externalPositionsLoading, setExternalPositionsLoading] =
+    useState(true);
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [externalPositions, setExternalPositions] = useState<ExternalPosition[]>([]);
   const isGTMediumScreen = useMediaQuery(RESPONSIVE_BREAKPOINTS.MD);
+
+  const { poolDataMap } = useContext(BlendTableContext);
+  const loadData = useCallback(async () => {
+    let poolData = Array.from(poolDataMap.values()) as BlendPoolMarkers[];
+    if (!accountData?.address || poolData.length === 0) {
+      return;
+    }
+    try {
+      const shareBalancesResponse = await http.get(
+        `${API_URL}/share_balances/${accountData.address}/1/1d/${(
+          new Date().getTime() / 1000
+        ).toFixed(0)}`
+      );
+      const positionRequests = Object.entries(shareBalancesResponse.data).map(
+        async (entry: any) => {
+          return {
+            pool: poolDataMap.get(entry[0]) as BlendPoolMarkers,
+            balance: entry[1][entry[1].length - 1].balance,
+            poolReturns: await axios.get(
+              `${API_URL}/pool_returns/${entry[0]}/1/1d/${(
+                new Date().getTime() / 1000
+              ).toFixed(0)}`
+            ),
+            poolStats: await axios.get(`${API_URL}/pool_stats/${entry[0]}/1`),
+          };
+        }
+      );
+      const positionResponses = await Promise.all(positionRequests);
+      const positionsData = positionResponses.map((positionResponse) => {
+        const pool = positionResponse.pool;
+        const balance = positionResponse.balance;
+        const totalSupply =
+          positionResponse.poolReturns.data[positionResponse.poolReturns.data.length - 1]
+            .total_supply;
+        const totalValueLocked = positionResponse.poolStats.data[0].total_value_locked;
+        const estimatedValue = (balance / totalSupply) * totalValueLocked;
+        return {
+          pool,
+          estimatedValue,
+        };
+      });
+      setPositions(positionsData);
+      setPositionsLoading(false);
+    } catch (e) {
+      console.log(e);
+      setPositionsLoading(false);
+    }
+
+    const uniswapPositionRequests = poolData.map(async (pool) => {
+      const pairAddress = poolToUniswapV2Pair(pool.poolAddress);
+      return {
+        pool: pool,
+        etherscanData: await http.get(
+          `https://api.etherscan.io/api?module=account&action=tokenbalance&contractaddress=${pairAddress}&address=${accountData.address}&tag=latest&apikey=F7XAB91MQBBZ1HSCUEI343VVP7CTASW4N1`
+        ),
+        uniswapData: await theGraphUniswapV2Client.query({
+          query: getUniswapPairValueQuery(pairAddress),
+        }),
+      };
+    });
+    const uniswapPositionResponse = await Promise.all(uniswapPositionRequests);
+    const filtered = uniswapPositionResponse.filter((uniswapPosition) => {
+      // TODO: make this more robust
+      return parseInt(uniswapPosition.etherscanData.data.result) > 0;
+    });
+    const uniswapPositionData = filtered.map((uniswapPosition) => {
+      const userBalance = parseInt(uniswapPosition.etherscanData.data.result) / 10 ** 18;
+      const pairTotalSupply = parseFloat(uniswapPosition.uniswapData.data.pair.totalSupply);
+      const pairValue = parseFloat(uniswapPosition.uniswapData.data.pair.reserveUSD);
+      return {
+        pool: uniswapPosition.pool,
+        estimatedValue: (userBalance * pairValue) / pairTotalSupply,
+        externalPositionName: 'Uniswap V2',
+      };
+    });
+    setExternalPositions(uniswapPositionData);
+    setExternalPositionsLoading(false);
+  }, [accountData?.address, poolDataMap]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
   return (
     <AppPage>
       <Container>
         <div className='w-full'>
-          <PortfolioGraph />
+          {accountData && (
+            <PortfolioGraph accountAddress={accountData.address} />
+          )}
         </div>
-        <div className='w-full'>
-          <EmptyPortfolio />
-        </div>
-        <div className='w-full'>
+        <div className='w-full max-w-[1280px]'>
           <Text size='XL' weight='medium' color={PORTFOLIO_TITLE_TEXT_COLOR}>
             Your Portfolio
           </Text>
-          <PortfolioCards>
-            <PortfolioCard
-              token0={GetTokenData(
-                '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-              )}
-              token1={GetTokenData(
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-              )}
-              silo0={GetSiloData('0x723bfe564661536fdffa3e9e060135928d3bf18f')}
-              silo1={GetSiloData('0x8f43969d04ba8aaec7c69813a07a276189c574d2')}
-              uniswapFeeTier={FeeTier.ZERO_THREE}
-              estimatedValue={1930.48}
-              percentageChange={2}
-            />
-            <PortfolioCard
-              token0={GetTokenData(
-                '0x03ab458634910aad20ef5f1c8ee96f1d6ac54919'
-              )}
-              token1={GetTokenData(
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-              )}
-              silo0={GetSiloData('0xf70fc6b694d911b1f665b754f77ec5e83d340594')}
-              silo1={GetSiloData('0x8f43969d04ba8aaec7c69813a07a276189c574d2')}
-              uniswapFeeTier={FeeTier.ZERO_THREE}
-              estimatedValue={1930.48}
-              percentageChange={-1}
-            />
-            <PortfolioCard
-              token0={GetTokenData(
-                '0x956f47f50a910163d8bf957cf5846d573e7f87ca'
-              )}
-              token1={GetTokenData(
-                '0xc7283b66eb1eb5fb86327f08e1b5816b0720212b'
-              )}
-              silo0={GetSiloData('0x0770d239e56d96bc1e049b94949b0a0199b77cf6')}
-              silo1={GetSiloData('0x2a9855dc8afa59e6067287b8aa15cd009938d137')}
-              uniswapFeeTier={FeeTier.ZERO_THREE}
-              estimatedValue={1930.48}
-              percentageChange={-1}
-            />
-            <PortfolioCard
-              token0={GetTokenData(
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-              )}
-              token1={GetTokenData(
-                '0xf4d2888d29d722226fafa5d9b24f9164c092421e'
-              )}
-              silo0={GetSiloData('0x0a230cca01f7107933d5355913e9a65082f37c52')}
-              silo1={GetSiloData('0x7a17db19e5bfe3e96d6a8da9c100ac86a4650d54')}
-              uniswapFeeTier={FeeTier.ZERO_THREE}
-              estimatedValue={1930.48}
-              percentageChange={-1}
-            />
-          </PortfolioCards>
+          {(positionsLoading || positions.length > 0) && (
+            <PortfolioCards>
+              {!positionsLoading &&
+                positions.length > 0 &&
+                positions.map((position, index) => {
+                  return (
+                    <PortfolioCard
+                      key={index}
+                      token0={GetTokenData(
+                        position.pool.token0Address.toLowerCase()
+                      )}
+                      token1={GetTokenData(
+                        position.pool.token1Address.toLowerCase()
+                      )}
+                      silo0={GetSiloData(
+                        position.pool.silo0Address.toLowerCase()
+                      )}
+                      silo1={GetSiloData(
+                        position.pool.silo1Address.toLowerCase()
+                      )}
+                      uniswapFeeTier={position.pool.feeTier}
+                      estimatedValue={position.estimatedValue}
+                      percentageChange={0}
+                    />
+                  );
+                })}
+              {positionsLoading && <PortfolioCardPlaceholder /> }
+            </PortfolioCards>
+          )}
+          {!positionsLoading && positions.length === 0 && (
+            <div className='w-full mt-6'>
+              <EmptyPortfolio />
+            </div>
+          )}
         </div>
-        <div className='w-full'>
+        <div className='w-full max-w-[1280px]'>
           <div className='flex justify-between items-center'>
-            <Text size='XL' weight='medium' color={PORTFOLIO_TITLE_TEXT_COLOR}>
+            <Text
+              size='XL'
+              weight='medium'
+              color={PORTFOLIO_TITLE_TEXT_COLOR}
+            >
               Your External Positions
             </Text>
             <Tooltip
@@ -111,33 +230,32 @@ export default function PortfolioPage() {
               filled={true}
             />
           </div>
-          <PortfolioCards>
-            <ExternalPortfolioCard
-              token0={GetTokenData(
-                '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-              )}
-              token1={GetTokenData(
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-              )}
-              uniswapFeeTier={FeeTier.ZERO_THREE}
-              estimatedValue={1930.48}
-              percentageChange={2}
-            />
-            <ExternalPortfolioCard
-              token0={GetTokenData(
-                '0x03ab458634910aad20ef5f1c8ee96f1d6ac54919'
-              )}
-              token1={GetTokenData(
-                '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-              )}
-              uniswapFeeTier={FeeTier.ZERO_THREE}
-              estimatedValue={1930.48}
-              percentageChange={-1}
-            />
-          </PortfolioCards>
-        </div>
-        <div className='w-full'>
-          <EmptyExternalPortfolio />
+          {(externalPositionsLoading || externalPositions.length > 0) && (
+            <PortfolioCards>
+              {!externalPositionsLoading &&
+                externalPositions.length > 0 &&
+                externalPositions.map((position, index) => (
+                  <ExternalPortfolioCard
+                    key={index}
+                    token0={GetTokenData(
+                      position.pool.token0Address.toLowerCase()
+                    )}
+                    token1={GetTokenData(
+                      position.pool.token1Address.toLowerCase()
+                    )}
+                    externalPositionName={position.externalPositionName}
+                    estimatedValue={position.estimatedValue}
+                    percentageChange={0}
+                  />
+                ))}
+              {externalPositionsLoading && <ExternalPortfolioCardPlaceholder />}
+            </PortfolioCards>
+          )}
+          {!externalPositionsLoading && externalPositions.length === 0 && (
+            <div className='w-full mt-6'>
+              <EmptyExternalPortfolio />
+            </div>
+          )}
         </div>
       </Container>
     </AppPage>

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -170,9 +170,7 @@ export default function PortfolioPage() {
     <AppPage>
       <Container>
         <div className='w-full'>
-          {accountData && (
-            <PortfolioGraph accountAddress={accountData.address} />
-          )}
+          <PortfolioGraph accountAddress={accountData ? accountData.address : null} />
         </div>
         <div className='w-full max-w-[1280px]'>
           <Text size='XL' weight='medium' color={PORTFOLIO_TITLE_TEXT_COLOR}>

--- a/src/util/GraphQL.ts
+++ b/src/util/GraphQL.ts
@@ -40,3 +40,14 @@ export function getUniswapVolumeQuery(
   }
   `;
 }
+
+export function getUniswapPairValueQuery(pairAddress: string) {
+  return gql`
+  {
+    pair(id: "${pairAddress}") {
+      reserveUSD
+      totalSupply
+    }
+  }
+  `
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,6 +3422,11 @@ axe-core@^4.3.5:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.0.tgz"
   integrity sha512-btWy2rze3NnxSSxb7LtNhPYYFrRoFBfjiGzmSc/5Hu47wApO2KNXjP/w7Nv2Uz/Fyr/pfEiwOkcXhDxu0jz5FA==
 
+axios-rate-limit@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/axios-rate-limit/-/axios-rate-limit-1.3.0.tgz#03241d24c231c47432dab6e8234cfde819253c2e"
+  integrity sha512-cKR5wTbU/CeeyF1xVl5hl6FlYsmzDVqxlN4rGtfO5x7J83UxKDckudsW0yW21/ZJRcO0Qrfm3fUFbhEbWTLayw==
+
 axios@^0.21.0:
   version "0.21.4"
   resolved "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz"


### PR DESCRIPTION
As the title suggests, I began integrating the portfolio page. This includes fetching the data about a user's aloe positions as well as Uniswap v2 positions to display on their portfolio as well as the logic to display the empty states when the user doesn't have the respective position(s) (aloe/external). One thing that still needs to be done is the calculations for percentage change for both types of positions. Additionally, the logic needs a bit more error handling in order to make sure it is robust and doesn't crash ever (it shouldn't, but it is better to be safe). Lastly, as usual, below I attached some images of a few of the different states/cards (the ones with actual numbers are using addresses I found on etherscan):
![portfolio-state](https://user-images.githubusercontent.com/17186604/179379239-4e14e4b0-2a84-437d-9183-349aa9c7bccc.PNG)
![portfolio-state2](https://user-images.githubusercontent.com/17186604/179379241-012dd1d6-42e0-4556-b3fe-950bbfbd910f.PNG)
![portfolio-state3](https://user-images.githubusercontent.com/17186604/179379245-d0c661d5-81d5-4f01-b58f-4c7fd3a792c8.PNG)

