### PR TITLE
Removing the portfolio page temporarily

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,7 +111,7 @@ function App() {
                       element={<Navigate replace to='/blend/pools' />}
                     />
                   </Route>
-                  <Route path='/portfolio' element={<PortfolioPage />} />
+                  {/* <Route path='/portfolio' element={<PortfolioPage />} /> */}
                   { // Devmode-only example page routing
                     IS_DEV && (
                       <>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -24,12 +24,12 @@ const menuItems: MenuItem[] = [
     name: 'blend',
     url: '/blend',
   },
-  {
-    title: 'Portfolio',
-    name: 'portfolio',
-    url: '/portfolio',
-    onlyShowIfConnected: true,
-  }
+  // {
+  //   title: 'Portfolio',
+  //   name: 'portfolio',
+  //   url: '/portfolio',
+  //   onlyShowIfConnected: true,
+  // }
 ];
 
 if (IS_DEV) {


### PR DESCRIPTION
Since the portfolio page got prematurely merged, we need to remove it temporarily until it is finished.