### PR TITLE
Fixing functionality without the api running

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import GovernancePage from './pages/GovernancePage';
 
 import AppBody from './components/common/AppBody';
 import { RedirectPartialPath } from './util/RedirectPartialPath';
-import { BlendTableProvider } from './data/context/BlendTableContext';
 import ScrollToTop from './util/ScrollToTop';
 import { IS_DEV } from './util/Env';
 import ButtonExamplesPage from './pages/ButtonExamplesPage';
@@ -82,52 +81,55 @@ function App() {
     <>
       <Suspense fallback={null}>
         <WagmiProvider>
-          <BlendTableProvider>
-            <ScrollToTop />
-            <AppBody>
-              <Header />
-              <main className='flex-grow'>
-                <Routes>
+          <ScrollToTop />
+          <AppBody>
+            <Header />
+            <main className='flex-grow'>
+              <Routes>
+                <Route
+                  path='/blend'
+                  element={
+                    <RedirectPartialPath
+                      from={['/blend', '/blend/']}
+                      to={'/blend/pools'}
+                    />
+                  }
+                >
                   <Route
-                    path='/blend'
-                    element={
-                      <RedirectPartialPath
-                        from={['/blend', '/blend/']}
-                        to={'/blend/pools'}
-                      />
-                    }
-                  >
-                    <Route path='pools' element={<BlendPoolSelectPage blockNumber={blockNumber} />} />
-                    <Route
-                      path='pool/:pooladdress'
-                      element={<BlendPoolPage blockNumber={blockNumber} />}
-                    />
-                    <Route
-                      path='pool'
-                      element={<Navigate replace to='/blend' />}
-                    />
-                    <Route
-                      path='*'
-                      element={<Navigate replace to='/blend/pools' />}
-                    />
-                  </Route>
-                  {/* <Route path='/portfolio' element={<PortfolioPage />} /> */}
-                  { // Devmode-only example page routing
-                    IS_DEV && (
-                      <>
-                        <Route path='/buttons' element={<ButtonExamplesPage />} />
-                        <Route path='/inputs' element={<InputExamplesPage />} />
-                        <Route path='/portfolio' element={<PortfolioPage />} />
-                        <Route path='/governance' element={<GovernancePage />} />
-                      </>
-                  )}
-                  <Route path='/' element={<Navigate replace to='/blend' />} />
-                  <Route path='*' element={<Navigate to='/' />} />
-                </Routes>
-              </main>
-              <Footer />
-            </AppBody>
-          </BlendTableProvider>
+                    path='pools'
+                    element={<BlendPoolSelectPage blockNumber={blockNumber} />}
+                  />
+                  <Route
+                    path='pool/:pooladdress'
+                    element={<BlendPoolPage blockNumber={blockNumber} />}
+                  />
+                  <Route
+                    path='pool'
+                    element={<Navigate replace to='/blend' />}
+                  />
+                  <Route
+                    path='*'
+                    element={<Navigate replace to='/blend/pools' />}
+                  />
+                </Route>
+                {/* <Route path='/portfolio' element={<PortfolioPage />} /> */}
+                {
+                  // Devmode-only example page routing
+                  IS_DEV && (
+                    <>
+                      <Route path='/buttons' element={<ButtonExamplesPage />} />
+                      <Route path='/inputs' element={<InputExamplesPage />} />
+                      <Route path='/portfolio' element={<PortfolioPage />} />
+                      <Route path='/governance' element={<GovernancePage />} />
+                    </>
+                  )
+                }
+                <Route path='/' element={<Navigate replace to='/blend' />} />
+                <Route path='*' element={<Navigate to='/' />} />
+              </Routes>
+            </main>
+            <Footer />
+          </AppBody>
         </WagmiProvider>
       </Suspense>
     </>

--- a/src/components/browse/BrowseCard.tsx
+++ b/src/components/browse/BrowseCard.tsx
@@ -32,6 +32,8 @@ import {
 import { Display, Text } from '../common/Typography';
 import { theGraphUniswapV3Client } from '../../App';
 import { getUniswapVolumeQuery } from '../../util/GraphQL';
+import axios from 'axios';
+import { API_URL, IS_API_ENABLED } from '../../data/constants/Values';
 
 const CARD_BODY_BG_COLOR = 'rgba(13, 23, 30, 1)';
 const FEE_TIER_BG_COLOR = 'rgba(26, 41, 52, 1)';
@@ -163,6 +165,24 @@ export default function BrowseCard(props: BrowseCardProps) {
   const silo0 = GetSiloData(blendPoolMarkers.silo0Address.toLocaleLowerCase());
   const silo1 = GetSiloData(blendPoolMarkers.silo1Address.toLocaleLowerCase());
   const feeTier = PrintFeeTier(blendPoolMarkers.feeTier);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchPoolStats = async () => {
+      if (!IS_API_ENABLED) return;
+      const poolStatsResponse = await axios.get(
+        `${API_URL}/pool_stats/${blendPoolMarkers.poolAddress}/1`
+      );
+      const poolStatsData = poolStatsResponse.data[0] as OffChainPoolStats;
+      if (mounted && poolStatsData) {
+        setPoolStats(poolStatsData);
+      }
+    };
+    fetchPoolStats();
+    return () => {
+      mounted = false;
+    };
+  }, [blendPoolMarkers.poolAddress]);
 
   useEffect(() => {
     let mounted = true;

--- a/src/components/browse/BrowseCard.tsx
+++ b/src/components/browse/BrowseCard.tsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
@@ -15,7 +14,6 @@ import {
   RESPONSIVE_BREAKPOINT_MD,
   RESPONSIVE_BREAKPOINT_SM,
 } from '../../data/constants/Breakpoints';
-import { API_URL } from '../../data/constants/Values';
 import { OffChainPoolStats } from '../../data/PoolStats';
 import { GetSiloData } from '../../data/SiloData';
 import { GetTokenData } from '../../data/TokenData';
@@ -187,23 +185,6 @@ export default function BrowseCard(props: BrowseCardProps) {
       mounted = false;
     };
   }, [blendPoolMarkers.feeTier, blockNumber, token0.address, token1.address]);
-
-  useEffect(() => {
-    let mounted = true;
-    const fetchPoolStats = async () => {
-      const poolStatsResponse = await axios.get(
-        `${API_URL}/pool_stats/${blendPoolMarkers.poolAddress}/1`
-      );
-      const poolStatsData = poolStatsResponse.data[0] as OffChainPoolStats;
-      if (mounted && poolStatsData) {
-        setPoolStats(poolStatsData);
-      }
-    };
-    fetchPoolStats();
-    return () => {
-      mounted = false;
-    };
-  }, [blendPoolMarkers.poolAddress]);
 
   // TODO: Move this to a utility function
   useEffect(() => {

--- a/src/components/browse/BrowsePoolsPerformance.tsx
+++ b/src/components/browse/BrowsePoolsPerformance.tsx
@@ -1,10 +1,8 @@
-import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import tw from 'twin.macro';
 import { BlendPoolMarkers } from '../../data/BlendPoolMarkers';
 import { RESPONSIVE_BREAKPOINT_SM } from '../../data/constants/Breakpoints';
-import { API_URL } from '../../data/constants/Values';
 import { GlobalStats } from '../../data/GlobalStats';
 import { formatUSD } from '../../util/Numbers';
 import { Display, Text } from '../common/Typography';
@@ -58,25 +56,6 @@ export default function BrowsePoolsPerformance(
   props: BrowsePoolsPerformanceProps
 ) {
   const [globalStats, setGlobalStats] = useState<GlobalStats>();
-
-  useEffect(() => {
-    let mounted = true;
-    const fetchGlobalStats = async () => {
-      const res = await axios.get(`${API_URL}/global_stats`);
-      const data = res.data[0];
-      if (mounted && data) {
-        setGlobalStats({
-          poolCount: data['pool_count'],
-          users: data['users'],
-          totalValueLocked: data['total_value_locked'],
-        });
-      }
-    };
-    fetchGlobalStats();
-    return () => {
-      mounted = false;
-    };
-  }, []);
 
   return (
     <Wrapper>

--- a/src/components/browse/BrowsePoolsPerformance.tsx
+++ b/src/components/browse/BrowsePoolsPerformance.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import tw from 'twin.macro';
 import { BlendPoolMarkers } from '../../data/BlendPoolMarkers';
 import { RESPONSIVE_BREAKPOINT_SM } from '../../data/constants/Breakpoints';
+import { API_URL, IS_API_ENABLED } from '../../data/constants/Values';
 import { GlobalStats } from '../../data/GlobalStats';
 import { formatUSD } from '../../util/Numbers';
 import { Display, Text } from '../common/Typography';
@@ -56,6 +58,26 @@ export default function BrowsePoolsPerformance(
   props: BrowsePoolsPerformanceProps
 ) {
   const [globalStats, setGlobalStats] = useState<GlobalStats>();
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchGlobalStats = async () => {
+      if (!IS_API_ENABLED) return;
+      const res = await axios.get(`${API_URL}/global_stats`);
+      const data = res.data[0];
+      if (mounted && data) {
+        setGlobalStats({
+          poolCount: data['pool_count'],
+          users: data['users'],
+          totalValueLocked: data['total_value_locked'],
+        });
+      }
+    };
+    fetchGlobalStats();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   return (
     <Wrapper>

--- a/src/data/constants/Values.ts
+++ b/src/data/constants/Values.ts
@@ -8,3 +8,4 @@ export const DEFAULT_RATIO_CHANGE = '5.0';
 export const RATIO_CHANGE_CUTOFF = 0;
 export const API_URL = 'https://api.aloe.capital';
 export const GAS_ESTIMATION_SCALING = 1.1;
+export const IS_API_ENABLED = false;

--- a/src/pages/BlendPoolPage.tsx
+++ b/src/pages/BlendPoolPage.tsx
@@ -32,6 +32,8 @@ import { getUniswapVolumeQuery } from '../util/GraphQL';
 import { IOSStyleSpinner } from '../components/common/Spinner';
 import PoolAnnotation from '../components/pool/PoolAnnotation';
 import { fetchBlendPoolData } from '../data/BlendPoolFinder';
+import axios from 'axios';
+import { API_URL, IS_API_ENABLED } from '../data/constants/Values';
 
 const ABOUT_MESSAGE_TEXT_COLOR = 'rgba(130, 160, 182, 1)';
 
@@ -160,6 +162,26 @@ export default function BlendPoolPage(props: BlendPoolPageProps) {
       mounted = false;
     }
   }, [params.pooladdress, provider]);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchPoolStats = async () => {
+      if (!IS_API_ENABLED) return;
+      const response = await axios.get(
+        `${API_URL}/pool_stats/${poolData?.poolAddress}/1`
+      );
+      const poolStatsData = response.data[0] as OffChainPoolStats;
+      if (mounted && poolStatsData) {
+        setOffChainPoolStats(poolStatsData);
+      }
+    };
+    if (poolData) {
+      fetchPoolStats();
+    }
+    return () => {
+      mounted = false;
+    }
+  }, [poolData]);
 
   useEffect(() => {
     let mounted = true;

--- a/src/pages/BlendPoolSelectPage.tsx
+++ b/src/pages/BlendPoolSelectPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as PlusIcon } from '../assets/svg/white_plus.svg';
 import BrowseCard from '../components/browse/BrowseCard';
@@ -26,7 +26,6 @@ import {
   RESPONSIVE_BREAKPOINT_SM,
   RESPONSIVE_BREAKPOINTS,
 } from '../data/constants/Breakpoints';
-import { BlendTableContext } from '../data/context/BlendTableContext';
 import { GetTokenData } from '../data/TokenData';
 import { ReactComponent as SearchIcon } from '../assets/svg/search.svg';
 import useMediaQuery from '../data/hooks/UseMediaQuery';
@@ -38,10 +37,10 @@ import { isPoolDeprecated } from '../util/Pool';
 import { ReactComponent as APYIcon } from '../assets/svg/apy.svg';
 import { SortAscendingIcon, SortDescendingIcon } from '@heroicons/react/solid';
 import { OffChainPoolStats } from '../data/PoolStats';
-import axios, { AxiosResponse } from 'axios';
-import { API_URL } from '../data/constants/Values';
 import { makeEtherscanRequest } from '../util/Etherscan';
 import { BigNumber } from 'ethers';
+import { useProvider } from 'wagmi';
+import { fetchBlendPoolData } from '../data/BlendPoolFinder';
 
 const FACTORY_ADDRESS = '0x000000000008b34b9C428ddC00f54d49105dA313';
 const TOPIC_ZERO =
@@ -169,7 +168,7 @@ export default function BlendPoolSelectPage(props: BlendPoolSelectPageProps) {
     useState<DropdownWithPlaceholderValueOption>(sortByOptions[0]);
 
   const isGTMediumScreen = useMediaQuery(RESPONSIVE_BREAKPOINTS.MD);
-  const { poolDataMap } = useContext(BlendTableContext);
+  const provider = useProvider();
 
   const isMounted = useRef(false);
 
@@ -181,42 +180,26 @@ export default function BlendPoolSelectPage(props: BlendPoolSelectPageProps) {
   }, []);
 
   const loadData = useCallback(async () => {
-    let poolData = Array.from(poolDataMap.values()) as BlendPoolMarkers[];
-    const poolRequests = poolData.map(async (pool) => {
-      return {
-        poolData: pool,
-        poolStats: await axios.get(
-          `${API_URL}/pool_stats/${pool.poolAddress}/1`,
-          {
-            transformResponse: (response) => {
-              const responseJSON = JSON.parse(response)[0];
-              return responseJSON as OffChainPoolStats;
-            },
-          }
-        ),
-      };
-    });
-    const poolStatsDataResponse = await Promise.all(poolRequests);
-    // Fetch the intermediate data (everything except the timestamp)
-    // TODO: see if we can move move the timestamp call into the above promise.all
-    const intermediatePoolStatsData: IntermediatePoolStatsData[] = poolStatsDataResponse.map(
-      (response: {
-        poolData: BlendPoolMarkers;
-        poolStats: AxiosResponse<any, any>;
-      }) => {
-        return {
-          poolData: response.poolData,
-          poolStats: response.poolStats.data,
-        };
-      }
-    );
-    // Fetch the timestamps for all the pools
     const factoryCreationEventsRequest = await makeEtherscanRequest(
       BLOCK_TO_SEARCH_FROM,
       FACTORY_ADDRESS,
       [TOPIC_ZERO],
       false
     );
+    const results = factoryCreationEventsRequest.data.result;
+    const pools = results.map((result: any) => {
+      const topic1: string = result.topics[1];
+      const currentPoolAddress = `0x${topic1.slice(26)}`;
+      return currentPoolAddress;
+    });
+    const blendPoolMarkers: BlendPoolMarkers[] = await Promise.all(pools.map((pool: string) => {
+      return fetchBlendPoolData(pool, provider);
+    }));
+    const intermediatePoolStatsData: IntermediatePoolStatsData[] = blendPoolMarkers.map((pool: BlendPoolMarkers) => {
+      return {
+        poolData: pool,
+      }
+    });
     const poolStatsData = intermediatePoolStatsData.map((poolStats) => {
       const poolCreationEvent = factoryCreationEventsRequest.data.result.find(
         (event: any) => {
@@ -244,7 +227,7 @@ export default function BlendPoolSelectPage(props: BlendPoolSelectPageProps) {
     if (isMounted.current) {
       setPools(nonDeprecatedPoolData);
       setSearchablePools(poolStatsData);
-      if (poolData.length > 0) {
+      if (pools.length > 0) {
         setPoolsLoading(false);
       }
     }
@@ -269,7 +252,7 @@ export default function BlendPoolSelectPage(props: BlendPoolSelectPageProps) {
       setTokenOptions(tokenOptionData);
       setActiveTokenOptions(tokenOptionData);
     }
-  }, [poolDataMap]);
+  }, [provider]);
 
   useEffect(() => {
     loadData();


### PR DESCRIPTION
While the analytics service is down for maintenance, we need users to still be able to interact with the core app functionality. This PR aims to enable most of the existing functionality without the API present. Some functionality, such as the graphs and the off-chain data, will not load as those calls have been removed (for now).